### PR TITLE
Enhancement -  Make kernel async enterable.

### DIFF
--- a/src/async_kernel/command.py
+++ b/src/async_kernel/command.py
@@ -138,7 +138,7 @@ def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_foreve
 
         async def _start() -> None:
             print("Starting kernel")
-            async with kernel.start_in_context():
+            async with kernel:
                 with contextlib.suppress(kernel.CancelledError):
                     await wait_exit_context()
 

--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -275,8 +275,8 @@ class Kernel(ConnectionFileMixin):
         """Start the kernel.
 
         - Only one instance can (should) run at a time.
-        - A kernel instance can only be started.
-        - A new instance can be started once the old instance is stopped.
+        - An instance can only be started once.
+        - A new instance can be started after a previous instance has stopped.
 
         Usage:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ async def kernel(anyio_backend, transport: str, tmp_path_factory):
     kernel.connection_file = str(connection_file.resolve())
     os.environ["MPLBACKEND"] = utils.MATPLOTLIB_INLINE_BACKEND  # Set this implicitly
     kernel.transport = transport
-    async with kernel.start_in_context():
+    async with kernel:
         yield kernel
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -52,7 +52,7 @@ def test_setattr_nested():
 
 def test_setattr_nested_has_traits():
     class TestObj(HasTraits):
-        k = CInt(load_default=False)
+        k = CInt()
         nested = Instance(HasTraits)
         nested_with_default = Instance(HasTraits)
 

--- a/tests/test_enter_kernel.py
+++ b/tests/test_enter_kernel.py
@@ -18,12 +18,12 @@ def anyio_backend(kernel_name: KernelName):
 
 
 async def test_start_kernel_in_context(anyio_backend, kernel_name):
-    async with Kernel().start_in_context() as kernel:
+    async with Kernel() as kernel:
         assert kernel.kernel_name == kernel_name
         connection_file = kernel.connection_file
         # Test prohibit nested async context.
         with pytest.raises(RuntimeError, match="Already started"):
-            async with kernel.start_in_context():
+            async with kernel:
                 pass
         # Test prevents binding socket more than once.
         with (
@@ -31,6 +31,6 @@ async def test_start_kernel_in_context(anyio_backend, kernel_name):
             kernel._bind_socket(SocketID.shell, None),  # pyright: ignore[reportArgumentType, reportPrivateUsage]
         ):
             pass
-    async with Kernel(connection_file=connection_file).start_in_context():
+    async with Kernel(connection_file=connection_file):
         # Test we can re-enter the kernel.
         pass


### PR DESCRIPTION
The kernel can now be started in context by using `async with kernel ...`.

## Breaking change

The method `start_in_context` is changed to a private variable `_start_in_context`.