### PR TITLE
Breaking changes to kernel initialisation and launching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,5 +88,5 @@ jobs:
         timeout-minutes: 5
         run: |
           uv sync --group docs
-          uv run async-kernel -a async-docs --shell.execute_request_timeout 0.1          
+          uv run async-kernel -a async-docs --shell.execute_request_timeout=0.1          
           uv run mkdocs build -s

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install the project
         run: |
           uv sync --group docs
-          uv run async-kernel -a async-docs --shell.execute_request_timeout 0.1    # The 'async-docs' kernel is specified as the kernel for mkdocs-jupyter
+          uv run async-kernel -a async-docs --shell.execute_request_timeout=0.1    # The 'async-docs' kernel is specified as the kernel for mkdocs-jupyter
 
       - name: Options
         id: mike

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Documentation is provided my [Material for MkDocs ](https://squidfunk.github.io/
 
 ```shell
 uv sync --group docs
-uv run async-kernel -a async-docs --shell.execute_request_timeout 0.1
+uv run async-kernel -a async-docs --shell.execute_request_timeout=0.1
 ```
 
 ### Serve locally

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Async kernel is a Python [Jupyter kernel](https://docs.jupyter.org/en/latest/pro
 
 ## Highlights
 
-- Concurrent message handling
+- [Concurrent message handling](https://fleming79.github.io/async-kernel/latest/notebooks/concurrency/)
 - [Debugger client](https://jupyterlab.readthedocs.io/en/latest/user/debugger.html#debugger)
-- Configurable backend
+- [Configurable backend](https://fleming79.github.io/async-kernel/latest/commands/#add-a-kernel-spec)
     - Asyncio (default)
         - [uvloop](https://pypi.org/project/uvloop/) enabled by default
     - [trio](https://pypi.org/project/trio/) backend

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,9 +2,9 @@
 
 `async-kernel` (and alias `async_kernel`) is provided on the command line. The main options are:
 
-- [Start a kernel](#start-a-kernel)
 - [Add kernel spec](#add-a-kernel-spec)
 - [Remove a kernel spec](#remove-a-kernel-spec)
+- [Start a kernel](#start-a-kernel)
 
 ## Add a kernel spec
 
@@ -23,20 +23,86 @@ Add a trio kernel spec.
 async-kernel -a async-trio
 ```
 
-!!! note
+### Custom arguments
 
-    To modify how the kernel start see the section on [starting a kernel](#start-a-kernel) for configuration options.
+Additional arguments can be included when defining the kernel spec, these include:
 
-### Configuration
+- Arguments for [async_kernel.kernelspec.write_kernel_spec][]
+    - `--kernel_factory`
+    - `--fullpath=False`
+    - `--display_name`
+    - `--prefix`
+- Nested attributes on the kernel via \`kernel.\<nested.attribute.name>'
 
-Additional configuration of the kernel spec is supported by passing the each parameter
-prefixed with '--' followed by the value.
+Each parameter should be specified as if it were a 'flag' as follows.
 
-The parameters are first used with creating the kernel spec.
+Prefix with "--" and join with the delimiter "=".
+
+```console
+--<PARAMETER or DOTTED.ATTRIBUTE.NAME>=<VALUE>
+```
+
+or, with compact notation to set a Boolean value as a Boolean flag.
+
+```console
+# True
+--<PARAMETER or DOTTED.ATTRIBUTE.NAME>
+
+# False
+--no-<PARAMETER or DOTTED.ATTRIBUTE.NAME>
+```
+
+#### Examples
+
+=== "write_kernel_spec argument"
+
+    **kernel_factory**
+
+    To specify an alternate kernel factory.
+
+    ```console
+    --kernel_factory=my_module.my_kernel_factory
+    ```
+
+    **fullpath (True)**
+
+    ```console
+    --fullpath
+    ```
+
+    **display name**
+
+    To set the kernel display name to `True`.
+
+    ```console
+    "--display_name=My kernel display name"
+    ```
+
+=== "Kernel attribute"
+
+    Set the execute request timeout trait on the kernel shell.
+
+    ```console
+    --shell.execute_request_timeout=0.1
+    ```
+
+=== "Kernel Boolean attribute as a flag"
+
+    Set `kernel.quiet=True`:
+
+    ```console
+    --quiet 
+    ```
+
+    Set `kernel.quiet=False`:
+
+    ```bash
+    --no=quiet 
+    ```
 
 ## Remove a kernel spec
 
-You can remove any kernel spec that is listed. Call `async-kernel` with no arguments to see a list of the installed kernels.
+Use the flag `-r` or `--remove` to remove a kernelspec.
 
 ```shell
 async-kernel
@@ -50,7 +116,8 @@ async-kernel -r async-trio-custom
 
 ## Start a kernel
 
-To start a kernel from the command prompt, use the argument `-f`.
+Use the flag `-f` or `--connection_file` followed by the full path to the connection file.
+To skip providing a connection file
 
 This will start the default kernel (async).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,18 +1,16 @@
 # Command line
 
-`async-kernel` (and alias `async_kernel`) is provided as a system executable.
-
-**Options:**
+`async-kernel` (and alias `async_kernel`) is provided on the command line. The main options are:
 
 - [Start a kernel](#start-a-kernel)
 - [Add kernel spec](#add-a-kernel-spec)
-- [Remove](#remove-a-kernel-spec)
+- [Remove a kernel spec](#remove-a-kernel-spec)
 
 ## Add a kernel spec
 
 Use the argument `-a` followed by the kernel name to add a new kernel spec.
 Include 'trio' in the kernel name to use a 'trio' backend. Any valid kernel name is
-allowed. Do not include whitespace in the kernel name.
+allowed (whitespace is not allowed).
 
 Recommended kernel names are:
 
@@ -63,7 +61,7 @@ async-kernel -f .
 Additional settings can be passed as arguments.
 
 ```shell
-async-kernel -f . --kernel_name async-trio-custom --display_name 'My custom kernel' --quiet False
+async-kernel -f . --kernel_name=async-trio-custom --display_name='My custom kernel' --quiet=False
 ```
 
 The call above will start a new kernel with a 'trio' backend. The quiet setting is

--- a/docs/reference/kernelspec.md
+++ b/docs/reference/kernelspec.md
@@ -1,0 +1,1 @@
+::: async_kernel.kernelspec

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://ipython.readthedocs.io/en/stable/objects.inv
             - https://ipykernel.readthedocs.io/en/stable/objects.inv
+            - https://jupyter-client.readthedocs.io/en/stable/objects.inv
             - https://anyio.readthedocs.io/en/stable/objects.inv
           options:
             docstring_options:
@@ -164,6 +165,7 @@ nav:
       - reference/caller.md
       - reference/command.md
       - reference/kernel.md
+      - reference/kernelspec.md
       - reference/asyncshell.md
       - reference/typing.md
       - reference/utils.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,11 @@ local_scheme = "no-local-version"
 minversion = "6.0"
 xfail_strict = true
 log_cli_level =  "INFO"
+# pytest-retry options. Ref: https://pypi.org/project/pytest-retry/
+retries = 2
+retry_delay = 0.5
+cumulative_timing = false
+retry_outcome = 'rerun'
 addopts = [
   "-raXs", "--durations=10", "--color=yes", "--doctest-modules",
    "--showlocals", "--strict-markers", "--strict-config",

--- a/src/async_kernel/command.py
+++ b/src/async_kernel/command.py
@@ -1,54 +1,25 @@
 from __future__ import annotations
 
 import argparse
-import contextlib
 import shutil
-import sys
-import traceback
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import anyio
 import traitlets
 
-from async_kernel.kernel import Kernel
-from async_kernel.kernelspec import Backend, KernelName, get_kernel_dir, write_kernel_spec
+from async_kernel.kernel import Kernel, run_kernel
+from async_kernel.kernelspec import KernelName, get_kernel_dir, write_kernel_spec
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from pathlib import Path
 
-    __all__ = ["command_line", "setattr_nested"]
-
-
-def setattr_nested(obj: object, name: str, value: str | Any) -> None:
-    """Set a nested attribute of an object.
-
-    If the attribute name contains dots, it is interpreted as a nested attribute.
-    For example, if name is "a.b.c", then the code will attempt to set obj.a.b.c to value.
-
-    This is primarily intended for use with [async_kernel.command.command_line][]
-    to set the nesteded attributes on on kernels.
-
-    Args:
-        obj: The object to set the attribute on.
-        name: The name of the attribute to set.
-        value: The value to set the attribute to.
-    """
-    if len(bits := name.split(".")) > 1:
-        try:
-            obj = getattr(obj, bits[0])
-        except Exception:
-            return
-        setattr_nested(obj, ".".join(bits[1:]), value)
-    if (isinstance(obj, traitlets.HasTraits) and obj.has_trait(name)) or hasattr(obj, name):
-        try:
-            setattr(obj, name, value)
-        except Exception:
-            setattr(obj, name, eval(value))
+    __all__ = ["command_line"]
 
 
 def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_forever) -> None:
-    """Parses command-line arguments to manage and start kernels.
+    """Parses command-line arguments to manage kernel specs and start kernels.
 
     This function uses `argparse` to handle command-line arguments for
     various kernel operations, including:
@@ -73,27 +44,22 @@ def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_foreve
             `anyio.sleep_forever`, which keeps the kernel running indefinitely
             until an external signal is received.
 
-    Command line arguments (args.argv):
-        Command line arguments
-
-        [argparse.ArgumentParser.parse_known_args][]
-
-        'unknownargs': Additional args provided from the command line are allowed
-            These are any arguments tha
-
     Raises:
         SystemExit: If an error occurs during kernel execution or if the
             program is interrupted.
-
-    ``` warning
-
-        Those familar with Configurable traits should not confuse this system
-        for setting attributes and traits with configurable traits. The difference
-        being that attributes are specified as the object relative to the base (kernel).
     """
+    title = "Async kernel"
     kernel_dir: Path = get_kernel_dir()
     parser = argparse.ArgumentParser(
-        description=str(command_line.__doc__),
+        description="=" * len(title)
+        + f"\n{title}\n"
+        + "=" * len(title)
+        + "\n\n"
+        + "With the async-kernel command line tool you can:\n\n"
+        + "    - Add/remove kernel specs\n"
+        + "    - start kernels\n\n"
+        + "Online help: https://fleming79.github.io/async-kernel/latest/commands/#command-line \n\n"
+        + f"Jupyter Kernel directory: '{kernel_dir}'",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -114,15 +80,20 @@ def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_foreve
         "-r",
         "--remove",
         dest="remove",
-        help=f"remove existing kernel specs. Installed kernels: {kernels}",
+        help=f"Remove existing kernel specs. Installed kernels: {kernels}.",
     )
     args, unknownargs = parser.parse_known_args()
+
+    # Convert unknownargs from flags to mappings
     for v in (v.lstrip("-") for v in unknownargs):
         if "=" in v:
             k, v_ = v.split("=", maxsplit=1)
             setattr(args, k, v_.strip("'\"").strip())
         else:
-            setattr(args, v, True)
+            # https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction
+            setattr(args, v.removeprefix("no-"), False) if v.startswith("no-") else setattr(args, v, True)
+
+    # Add kernel spec
     if args.add:
         if not hasattr(args, "kernel_name"):
             args.kernel_name = args.add
@@ -130,6 +101,8 @@ def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_foreve
             delattr(args, name)
         path = write_kernel_spec(**vars(args))
         print(f"Added kernel spec {path!s}")
+
+    # Remove kernel spec
     elif args.remove:
         for name in args.remove.split(","):
             folder = kernel_dir / str(name)
@@ -138,35 +111,17 @@ def command_line(wait_exit_context: Callable[[], Awaitable] = anyio.sleep_foreve
                 print(f"Removed kernel spec: {name}")
             else:
                 print(f"Kernel spec folder: '{name}' not found!")
-    elif not args.connection_file:
-        parser.print_help()
+
+    # Start kernel
+    elif args.connection_file:
+        factory: type[Kernel] = traitlets.import_item(pth) if (pth := getattr(args, "kernel_factory", "")) else Kernel
+        settings = vars(args)
+        for k in ["add", "remove", "kernel_factory"]:
+            settings.pop(k, None)
+        if settings.get("connection_file") in {None, "", "."}:
+            settings.pop("connection_file", None)
+        run_kernel(factory(settings), wait_exit_context)
+
+    # Default - print help
     else:
-        kernel_factory = getattr(args, "kernel_factory", None)
-        kernel_name: str = getattr(args, "kernel_name", None) or KernelName.asyncio
-        factory: type[Kernel] = traitlets.import_item(kernel_factory) if kernel_factory else Kernel
-        kernel = factory(kernel_name=kernel_name)
-        for k, v in vars(args).items():
-            if (k == "connection_file" and v == ".") or k in ["add", "remove"]:
-                continue
-            setattr_nested(kernel, k, v)
-
-        async def _start() -> None:
-            print(f"Starting kernel: {kernel_name=}")
-            async with kernel:
-                with contextlib.suppress(kernel.CancelledError):
-                    await wait_exit_context()
-
-        try:
-            backend = Backend.trio if "trio" in kernel_name.lower() else Backend.asyncio
-            anyio.run(_start, backend=backend, backend_options=kernel.anyio_backend_options.get(backend))
-        except KeyboardInterrupt:
-            pass
-        except BaseException as e:
-            traceback.print_exception(e, file=sys.stderr)
-            if sys.__stderr__ is not sys.stderr:
-                traceback.print_exception(e, file=sys.__stderr__)
-            sys.exit(1)
-        else:
-            sys.exit(0)
-        finally:
-            print("Kernel stopped: ", kernel.connection_file)
+        parser.print_help()

--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -862,7 +862,7 @@ class Kernel(ConnectionFileMixin):
         return (f"kernel.{topic}").encode()
 
     async def kernel_info_request(self, job: Job[Content], /) -> Content:
-        """Handle a ke[rnel info request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-info)."""
+        """Handle a [kernel info request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-info)."""
         return self.kernel_info
 
     async def comm_info_request(self, job: Job[Content], /) -> Content:

--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -34,7 +34,8 @@ from IPython.utils.tokenutil import token_at_cursor
 from jupyter_client.connect import ConnectionFileMixin
 from jupyter_client.session import Session
 from jupyter_core.paths import jupyter_runtime_dir
-from traitlets import CaselessStrEnum, CBool, Container, Dict, Instance, Int, Set, Tuple, UseEnum, default
+from traitlets import CaselessStrEnum, CBool, Container, Dict, Instance, Int, Set, Tuple, UseEnum, default, validate
+from typing_extensions import override
 from zmq import Context, Flag, PollEvent, Socket, SocketOption, SocketType, ZMQError
 
 import async_kernel
@@ -57,7 +58,7 @@ from async_kernel.typing import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable, Generator, Iterable
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterable
     from types import CoroutineType, FrameType
 
     from anyio.abc import TaskStatus
@@ -66,7 +67,7 @@ if TYPE_CHECKING:
     from async_kernel.comm import CommManager
 
 
-__all__ = ["Kernel", "KernelInterruptError"]
+__all__ = ["Kernel", "KernelInterruptError", "run_kernel"]
 
 
 def error_to_content(error: BaseException, /) -> Content:
@@ -162,6 +163,42 @@ def _wrap_handler(
     return wrap_handler
 
 
+def run_kernel(kernel: Kernel, wait_exit_context: Callable[[], Awaitable] = anyio.sleep_forever) -> None:
+    """Runs a kernel using AnyIO, handling exceptions and setting the exit code.
+
+    The kernel is started within an AnyIO context, allowing it to run using either
+    the Trio or Asyncio backend, determined by the kernel's name.  The function
+    handles KeyboardInterrupt exceptions gracefully and prints any other exceptions
+    to both `sys.stderr` and `sys.__stderr__` before exiting with a non-zero code.
+
+    Args:
+        kernel: The kernel to run, which must be an instance of a class implementing the Kernel protocol.
+        wait_exit_context: An optional callable that returns an awaitable. This awaitable
+            is awaited within the kernel's context.  It defaults to `anyio.sleep_forever`,
+            which keeps the kernel running until it is externally interrupted or cancelled.
+    """
+
+    async def _start() -> None:
+        async with kernel:
+            with contextlib.suppress(kernel.CancelledError):
+                await wait_exit_context()
+
+    try:
+        backend: Literal[Backend.trio, Backend.asyncio] = (
+            Backend.trio if "trio" in kernel.kernel_name.lower() else Backend.asyncio
+        )
+        anyio.run(_start, backend=backend, backend_options=kernel.anyio_backend_options.get(backend))
+    except KeyboardInterrupt:
+        pass
+    except BaseException as e:
+        traceback.print_exception(e, file=sys.stderr)
+        if sys.__stderr__ is not sys.stderr:
+            traceback.print_exception(e, file=sys.__stderr__)
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
 class KernelInterruptError(InterruptedError):
     "Raised to interrupt the kernel."
 
@@ -253,23 +290,30 @@ class Kernel(ConnectionFileMixin):
     transport: CaselessStrEnum[str] = CaselessStrEnum(
         ["tcp", "ipc"] if sys.platform == "linux" else ["tcp"], default_value="tcp", config=True
     )
+    _settings: Dict[str, Any] = Dict()
 
-    def __new__(cls, **kwargs) -> Self:  # noqa: ARG004
+    def __new__(cls, settings: dict | None = None, /) -> Self:  # noqa: ARG004
         #  There is only one instance.
         if not (instance := cls._instance):
             cls._instance = instance = super().__new__(cls)
         return instance
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, settings: dict | None = None, /) -> None:
         if self._initialised:
             return  # Only initialize once
         self._initialised = True
-        super().__init__(**kwargs)
+        super().__init__()
         sys.excepthook = self.excepthook
         sys.unraisablehook = self.unraisablehook
         signal.signal(signal.SIGINT, self._signal_handler)
         if not os.environ.get("MPLBACKEND"):
             os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"
+        self._settings = settings or {}
+
+    @override
+    def __repr__(self) -> str:
+        info = [f"{k}={v}" for k, v in self.settings.items()]
+        return f"{self.__class__.__name__}<{', '.join(info)}>"
 
     async def __aenter__(self) -> Self:
         """Start the kernel.
@@ -293,6 +337,17 @@ class Kernel(ConnectionFileMixin):
 
     async def __aexit__(self, exc_type, exc_value, exc_tb) -> None:
         await self.__stack.__aexit__(exc_type, exc_value, exc_tb)
+
+    @validate("_settings")
+    def _validate_settings(self, proposal) -> dict[str, Any]:
+        settings = self._settings or {"kernel_name": self.kernel_name}
+        for k, v in proposal.value.items():
+            settings |= utils.setattr_nested(self, k, v)
+        return settings
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        return {k: getattr(self, k) for k in ("kernel_name", "connection_file")} | self._settings
 
     @property
     def execution_count(self) -> int:
@@ -407,9 +462,7 @@ class Kernel(ConnectionFileMixin):
                     pathlib.Path(self.connection_file).parent.mkdir(parents=True, exist_ok=True)
                     self.write_connection_file()
                     atexit.register(self.cleanup_connection_file)
-                    print(
-                        f"""Kernel started with backend: {self.anyio_backend}. To connect a client use: --existing "{self.connection_file}" """
-                    )
+                    print(f"Kernel started: {self!r}")
                     await tg.start(self._start_iopub)
                     yield self
                 finally:
@@ -417,6 +470,7 @@ class Kernel(ConnectionFileMixin):
         finally:
             AsyncInteractiveShell.clear_instance()
             Context.instance().term()
+            print(f"Kernel stopped: {self!r}")
 
     def _signal_handler(self, signum, frame: FrameType | None) -> None:
         "Handle interrupt signals."

--- a/src/async_kernel/kernelspec.py
+++ b/src/async_kernel/kernelspec.py
@@ -29,36 +29,32 @@ class KernelName(enum.StrEnum):
 
 def make_argv(
     *,
-    connection_file="{connection_file}",
+    connection_file: str = "{connection_file}",
     kernel_name: KernelName | str = KernelName.asyncio,
-    kernel_factory="async_kernel.Kernel",
-    fullpath=True,
+    kernel_factory: str = "async_kernel.Kernel",
+    fullpath: bool = True,
     **kwargs,
 ) -> list[str]:
-    """Constructs the argument vector (argv) for launching a Python kernel module.
+    """Returns an argument vector (argv) that can be used to start a `Kernel`.
 
-    The backend is determined from the kernel_name. If the kernel_name contains 'trio'
-    (case-insensitive)a trio backend will be used otherwise an 'asyncio' backend is used.
+    This function returns a list of arguments can be used directly start a kernel with [subprocess.Popen][].
+    It will always call [async_kernel.command.command_line][] as a python module.
 
     Args:
         connection_file: The path to the connection file.
-        kernel_factory: The string import path to a callable that creates the kernel.
+        kernel_factory: The string import path to a callable that returns a non-started kernel.
+            It must accepts one positional argument the arguments passed as kwgs here.
         kernel_name: The name of the kernel to use.
         fullpath: If True the full path to the executable is used, otherwise 'python' is used.
 
     kwargs:
-        Additional settings to use on the instance of the Kernel.
-        kwargs are converted to key/value pairs, keys will be prefixed with '--'.
-        The kwargs should correspond to settings to set prior to starting. kwargs
-        are set on the
-        instance by eval on the value.
-        keys that correspond to an attribute on the kernel instance are not used.
+        Additional settings to pass when creating the kernel passed to `kernel_factory`.
+        When the kernel factThe key should be the dotted path to the attribute. Or if using a
 
     Returns:
         list: A list of command-line arguments to launch the kernel module.
     """
-    python = sys.executable if fullpath else "python"
-    argv = [python, "-m", "async_kernel", "-f", connection_file]
+    argv = [(sys.executable if fullpath else "python"), "-m", "async_kernel", "-f", connection_file]
     for k, v in ({"kernel_factory": kernel_factory, "kernel_name": kernel_name} | kwargs).items():
         argv.append(f"--{k}={v}")
     return argv
@@ -67,40 +63,34 @@ def make_argv(
 def write_kernel_spec(
     path: Path | str | None = None,
     *,
-    kernel_factory="async_kernel.Kernel",
-    connection_file="{connection_file}",
+    kernel_factory: str = "async_kernel.Kernel",
     kernel_name: KernelName | str = KernelName.asyncio,
-    fullpath=False,
-    display_name="",
-    prefix="",
+    fullpath: bool = False,
+    display_name: str = "",
+    connection_file: str = "{connection_file}",
+    prefix: str = "",
     **kwargs,
 ) -> Path:
     """
-    Write a kernel spec directory to `path` for launching a kernel.
-
-    The kernel spec always calls the 'python -m async_kernel' which calls
-    [][async_kernel.command.command_line][] [as a python module](https://docs.python.org/3/using/cmdline.html#command-line)).
-
+    Write a kernel spec for launching a kernel.
 
     Args:
-        connection_file: The path to the connection file.
+        path: The path where to write the spec.
         kernel_factory: The string import path to a callable that creates the Kernel.
         kernel_name: The name of the kernel to use.
         fullpath: If True the full path to the executable is used, otherwise 'python' is used.
         display_name: The display name for Jupyter to use for the kernel. The default is `"Python ({kernel_name})"`.
+        connection_file: The path to the connection file.
         prefix: given, the kernelspec will be installed to PREFIX/share/jupyter/kernels/KERNEL_NAME.
             This can be sys.prefix for installation inside virtual or conda envs.
 
     kwargs:
         Additional settings to use on the instance of the Kernel.
-        kwargs are converted to key/value pairs, keys will be prefixed with '--'.
-        The kwargs should correspond to settings to set prior to starting. kwargs
-        are set on the
-        instance by eval on the value.
-        keys that correspond to an attribute on the kernel instance are not used.
+        kwargs added to [KernelSpec.argv][jupyter_client.kernelspec.KernelSpec.argv]. When
+        The arguments are used as Kernel settings when starting the kernel.
     """
     assert _is_valid_kernel_name(kernel_name)
-    path = Path(path) if path else get_kernel_dir(prefix) / kernel_name
+    path = Path(path) if path else (get_kernel_dir(prefix) / kernel_name)
     # stage resources
     path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(RESOURCES, path, dirs_exist_ok=True)
@@ -124,7 +114,7 @@ def write_kernel_spec(
     return path
 
 
-def get_kernel_dir(prefix="") -> Path:
+def get_kernel_dir(prefix: str = "") -> Path:
     """The path to where kernel specs are stored for Jupyter.
 
     Args:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -81,7 +81,7 @@ def test_prints_help_when_no_args(monkeypatch, capsys):
 
 def test_add_kernel(monkeypatch, fake_kernel_dir: pathlib.Path, capsys):
     monkeypatch.setattr(
-        sys, "argv", ["prog", "-a", "async-trio", "--display_name", "my kernel", "--kernel_factory", "my.custom.class"]
+        sys, "argv", ["prog", "-a", "async-trio", "--display_name='my kernel'", "--kernel_factory=my.custom.class"]
     )
     command_line()
     out = capsys.readouterr().out
@@ -97,10 +97,8 @@ def test_add_kernel(monkeypatch, fake_kernel_dir: pathlib.Path, capsys):
             "async_kernel",
             "-f",
             "{connection_file}",
-            "--kernel_factory",
-            "my.custom.class",
-            "--kernel_name",
-            "async-trio",
+            "--kernel_factory=my.custom.class",
+            "--kernel_name=async-trio",
         ],
         "env": {},
         "display_name": "my kernel",
@@ -133,7 +131,7 @@ def test_remove_nonexistent_kernel(monkeypatch, fake_kernel_dir, capsys):
 
 
 def test_start_kernel_success(monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["prog", "-f", ".", "--kernel_name", "async", "--backend=asyncio"])
+    monkeypatch.setattr(sys, "argv", ["prog", "-f", ".", "--kernel_name=async", "--backend=asyncio"])
     started = False
 
     async def wait_exit():
@@ -172,7 +170,7 @@ async def test_subprocess_kernels_client(subprocess_kernels_client, kernel_name)
 
 def test_command_line(monkeypatch, kernel_name):
     # Start & Stop a kernel
-    monkeypatch.setattr(sys, "argv", ["prog", "-f", ".", "--quiet", "False", "shell.execute_request_timeout", "0.1"])
+    monkeypatch.setattr(sys, "argv", ["prog", "-f", ".", "--quiet=False", "--shell.execute_request_timeout=0.1"])
 
     async def wait_exit():
         kernel = async_kernel.Kernel()
@@ -189,7 +187,7 @@ def test_uv_loop_default(monkeypatch, disabled: bool):
     # Start a kernel with a uvloop
     args = ["prog", "-f", ".", "--"]
     if not disabled:
-        args.extend(("--anyio_backend_options", '{"asyncio":{}}'))
+        args.append('--anyio_backend_options={"asyncio":{}}')
     monkeypatch.setattr(sys, "argv", args)
 
     async def wait_exit():

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shutil
 import signal
 import sys
 import types
@@ -10,12 +9,11 @@ from typing import TYPE_CHECKING
 
 import anyio
 import pytest
-from traitlets import CInt, HasTraits, Instance, default
 
 import async_kernel
-from async_kernel import command as commandline_module
-from async_kernel.command import command_line, setattr_nested
-from async_kernel.kernelspec import Backend, KernelName, make_argv
+from async_kernel import kernel as kernel_module
+from async_kernel.command import command_line
+from async_kernel.kernelspec import Backend, make_argv
 from tests import utils
 
 if TYPE_CHECKING:
@@ -26,50 +24,9 @@ if TYPE_CHECKING:
 def fake_kernel_dir(tmp_path, monkeypatch):
     kernel_dir = tmp_path / "share/jupyter/kernels"
     kernel_dir.mkdir(parents=True)
-    monkeypatch.setattr(commandline_module, "sys", types.SimpleNamespace(prefix=str(tmp_path)))
+    monkeypatch.setattr(kernel_module, "sys", types.SimpleNamespace(prefix=str(tmp_path)))
     monkeypatch.setattr(sys, "prefix", str(tmp_path))
     return kernel_dir
-
-
-def test_setattr_nested():
-    class TestObj:
-        k = None
-        nested: TestObj
-
-    test_obj = TestObj()
-    test_obj.nested = TestObj()
-
-    # Directly set
-    setattr_nested(test_obj, "k", "1")
-    assert test_obj.k == "1"
-    # Nested
-    setattr_nested(test_obj, "nested.k", 2)
-    assert test_obj.nested.k == 2
-    # Does not set a missing attribute
-    setattr_nested(test_obj, "not_an_attribute", None)
-    assert not hasattr(test_obj, "not_an_attribute")
-
-
-def test_setattr_nested_has_traits():
-    class TestObj(HasTraits):
-        k = CInt()
-        nested = Instance(HasTraits)
-        nested_with_default = Instance(HasTraits)
-
-        @default("nested_with_default")
-        def _default_nested_with_default(self):
-            return TestObj()
-
-    test_obj = TestObj()
-    # Set with cast
-    setattr_nested(test_obj, "k", "1")
-    assert test_obj.k == 1
-    # Handles missing traits
-    setattr_nested(test_obj, "nested.k", "2")
-    assert not test_obj.trait_has_value("nested")
-    # Sets nested trait with a default
-    setattr_nested(test_obj, "nested_with_default.k", "2")
-    assert test_obj.nested_with_default.k == 2
 
 
 def test_prints_help_when_no_args(monkeypatch, capsys):
@@ -112,8 +69,6 @@ def test_remove_existing_kernel(monkeypatch, fake_kernel_dir, capsys):
     kernel_name = "asyncio"
     (fake_kernel_dir / kernel_name).mkdir()
     monkeypatch.setattr(sys, "argv", ["prog", "-r", kernel_name])
-    monkeypatch.setattr(commandline_module, "KernelName", KernelName)
-    monkeypatch.setattr(commandline_module, "shutil", shutil)
     command_line()
     out = capsys.readouterr().out
     assert f"Removed kernel spec: {kernel_name}" in out
@@ -123,8 +78,6 @@ def test_remove_existing_kernel(monkeypatch, fake_kernel_dir, capsys):
 def test_remove_nonexistent_kernel(monkeypatch, fake_kernel_dir, capsys):
     kernel_name = "notfound"
     monkeypatch.setattr(sys, "argv", ["prog", "-r", kernel_name])
-    monkeypatch.setattr(commandline_module, "KernelName", KernelName)
-    monkeypatch.setattr(commandline_module, "shutil", shutil)
     command_line()
     out = capsys.readouterr().out
     assert f"Kernel spec folder: '{kernel_name}' not found!" in out
@@ -143,7 +96,7 @@ def test_start_kernel_success(monkeypatch, capsys):
     assert e.value.code == 0
     assert started
     out = capsys.readouterr().out
-    assert "Starting kernel" in out
+    assert "Kernel started" in out
     assert "Kernel stopped" in out
 
 

--- a/tests/test_enter_kernel.py
+++ b/tests/test_enter_kernel.py
@@ -31,6 +31,6 @@ async def test_start_kernel_in_context(anyio_backend, kernel_name):
             kernel._bind_socket(SocketID.shell, None),  # pyright: ignore[reportArgumentType, reportPrivateUsage]
         ):
             pass
-    async with Kernel(connection_file=connection_file):
+    async with Kernel({"connection_file": connection_file}):
         # Test we can re-enter the kernel.
         pass

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -460,7 +460,7 @@ async def test_properties(kernel) -> None:
     kernel.user_ns = {}
 
 
-@pytest.mark.parametrize("code", argvalues=["%connect_info", "%matplotlib --list", "%callers"])
+@pytest.mark.parametrize("code", argvalues=["%connect_info", "%callers"])
 async def test_magic(client, code: str, kernel, monkeypatch):
     monkeypatch.setenv("JUPYTER_RUNTIME_DIR", str(pathlib.Path(kernel.connection_file).parent))
     assert code


### PR DESCRIPTION
`Kernel.__init__` now only accepts one non-positional argument - an optional dict for settings to load when initialising.

Breaking changes:

- Arguments are now passed as key=value instead of key value pairs

Kernel specs for older versions won't work.