### PR TITLE
Rename Caller.call_no_context to Caller.call_direct.

### DIFF
--- a/docs/notebooks/concurrency.ipynb
+++ b/docs/notebooks/concurrency.ipynb
@@ -191,7 +191,7 @@
     "    event = anyio.Event()\n",
     "    caller = Caller()  # Use caller so the `##thread` example works.\n",
     "    # This is because widget messages are received by the shell in the main thread. The event is being waited in this thread.\n",
-    "    button.on_click(lambda _: caller.call_no_context(event.set))\n",
+    "    button.on_click(lambda _: caller.call_direct(event.set))\n",
     "    display(button)\n",
     "    await event.wait()\n",
     "    button.close()\n",

--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -876,7 +876,7 @@ class Kernel(HasTraits):
                     "iopub_send: (thread=%s) msg_type:'%s', content: %s", thread.name, msg["msg_type"], msg["content"]
                 )
         else:
-            self.control_thread_caller.call_no_context(
+            self.control_thread_caller.call_direct(
                 self.iopub_send,
                 msg_or_type=msg_or_type,
                 content=content,
@@ -1070,7 +1070,7 @@ class Kernel(HasTraits):
     async def shutdown_request(self, job: Job[Content], /) -> Content:
         """Handle a [shutdown request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-shutdown) (control only)."""
         await self.debugger.disconnect()
-        Caller().call_no_context(self.stop)
+        Caller().call_direct(self.stop)
         return {"restart": job["msg"]["content"].get("restart", False)}
 
     async def debug_request(self, job: Job[Content], /) -> Content:

--- a/src/async_kernel/kernelspec.py
+++ b/src/async_kernel/kernelspec.py
@@ -129,7 +129,7 @@ def write_kernel_spec(
                     event = anyio.Event()
                     b = Button(description="Continue")
                     caller = Caller()
-                    b.on_click(lambda _: caller.call_no_context(event.set))
+                    b.on_click(lambda _: caller.call_direct(event.set))
                     display(b)
                     await event.wait()
                     b.close()


### PR DESCRIPTION
`call_no_context` is renamed to  `call_direct` 