### PR TITLE
Add classmethod  Caller.wait

### DIFF
--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -498,7 +498,7 @@ class Caller:
             self._to_thread_pool.remove(self)
 
     def call_later(
-        self, func: Callable[P, T | Awaitable[T]], delay: float = 0.0, /, *args: P.args, **kwargs: P.kwargs
+        self, delay: float, func: Callable[P, T | Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs
     ) -> Future[T]:
         """
         Schedule func to be called in caller's event loop copying the current context.
@@ -529,7 +529,7 @@ class Caller:
             *args: Arguments to use with func.
             **kwargs: Keyword arguments to use with func.
         """
-        return self.call_later(func, 0.0, *args, **kwargs)
+        return self.call_later(0, func, *args, **kwargs)
 
     def call_direct(self, func: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs) -> None:
         """

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -829,6 +829,7 @@ class Caller:
             if not shield:
                 for fut in futures:
                     fut.cancel("Cancelled  by as_completed")
+
     @classmethod
     def all_callers(cls, running_only: bool = True) -> list[Caller]:
         """

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -829,7 +829,6 @@ class Caller:
             if not shield:
                 for fut in futures:
                     fut.cancel("Cancelled  by as_completed")
-
     @classmethod
     def all_callers(cls, running_only: bool = True) -> list[Caller]:
         """

--- a/src/async_kernel/typing.py
+++ b/src/async_kernel/typing.py
@@ -22,6 +22,7 @@ __all__ = [
     "RunMode",
     "SocketID",
     "Tags",
+    "WaitType",
 ]
 
 NoValue = Sentinel("NoValue")
@@ -110,7 +111,7 @@ class RunMode(enum.StrEnum):
         **This mode blocks the message loop.** 
         
         Use this for short running messages that should be processed as soon as it is received.
-        """
+    """
 
 
 class KernelConcurrencyMode(enum.StrEnum):
@@ -175,7 +176,8 @@ class MetadataKeys(enum.StrEnum):
     This is an enum of keys for [metadata in kernel messages](https://jupyter-client.readthedocs.io/en/stable/messaging.html#metadata)
     that are used in async_kernel.
 
-    !!! Note
+    !!! note
+
         Metadata can be edited in Jupyter lab "Advanced tools" and Tags can be added using "common tools" in the [right side bar](https://jupyterlab.readthedocs.io/en/stable/user/interface.html#left-and-right-sidebar).
     """
 
@@ -237,6 +239,14 @@ class Tags(enum.StrEnum):
     
         The code block will return as 'ok' and there will be no message recorded.
     """
+
+
+class WaitType(enum.StrEnum):
+    "An enumeration of the 'wait_type' allowed for [async_kernel.caller.Caller.wait][]."
+
+    FIRST_COMPLETED = "FIRST_COMPLETED"
+    FIRST_EXCEPTION = "FIRST_EXCEPTION"
+    ALL_COMPLETED = "ALL_COMPLETED"
 
 
 class MsgHeader(TypedDict):

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -181,7 +181,7 @@ class TestCaller:
     async def test_sync(self):
         async with Caller(create=True) as caller:
             is_called = anyio.Event()
-            caller.call_later(is_called.set)
+            caller.call_later(0.01, is_called.set)
             await is_called.wait()
 
     def test_no_thread(self):
@@ -210,7 +210,7 @@ class TestCaller:
 
         async with Caller(create=True) as caller:
             is_called = anyio.Event()
-            fut = caller.call_later(my_func, 0.2, is_called, *args_kwargs[0], **args_kwargs[1])
+            fut = caller.call_later(0.1, my_func, is_called, *args_kwargs[0], **args_kwargs[1])
             await is_called.wait()
             assert val == args_kwargs
             assert (await fut) == args_kwargs
@@ -249,7 +249,7 @@ class TestCaller:
                     is_cancelled = True
 
             started = anyio.Event()
-            caller.call_later(my_test)
+            caller.call_later(0.01, my_test)
             await started.wait()
         assert is_cancelled
 
@@ -282,7 +282,7 @@ class TestCaller:
         else:
             expr = "invalid call"
             context = pytest.raises(SyntaxError)
-        fut = caller.call_later(eval, 0.2, expr)
+        fut = caller.call_later(0.01, eval, expr)
         with context:
             match check_mode:
                 case "main":
@@ -317,7 +317,7 @@ class TestCaller:
 
     async def test_wait_sync_error(self):
         async with Caller(create=True) as caller:
-            fut = caller.call_later(anyio.sleep, 0.1, 0.1)
+            fut = caller.call_later(0, anyio.sleep, 0.1)
             with pytest.raises(RuntimeError):
                 fut.wait_sync()
 
@@ -484,7 +484,7 @@ class TestCaller:
         fut = Caller.to_thread(close_tsc)
         caller = Caller.get_instance(fut.thread.name)
         ready.wait()
-        never_called_future = caller.call_later(str, 10)
+        never_called_future = caller.call_later(10, str)
         proceed.set()
         with pytest.raises(FutureCancelledError):
             await fut


### PR DESCRIPTION
This method is equivalent to asyncio.wait.

We also improve the resilience of asyncio.as_completed.