### PR TITLE
Stricter handling in Caller class.

### DIFF
--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -371,9 +371,9 @@ class Caller:
     _backend: Backend
     _queue_map: weakref.WeakKeyDictionary[Callable[..., Awaitable[Any]], MemoryObjectSendStream[tuple]]
     _taskgroup: TaskGroup | None = None
-    _callers: deque[tuple[contextvars.Context, Future] | Callable[[], Any]]
+    _jobs: deque[tuple[contextvars.Context, Future] | Callable[[], Any]]
     _thread: threading.Thread
-    _callers_added: threading.Event
+    _job_added: threading.Event
     _stopped_event: threading.Event
     _stopped = False
     _protected = False
@@ -428,8 +428,8 @@ class Caller:
             inst._backend = Backend(sniffio.current_async_library())
             inst._thread = thread
             inst.log = log or logging.LoggerAdapter(logging.getLogger())
-            inst._callers = deque()
-            inst._callers_added = threading.Event()
+            inst._jobs = deque()
+            inst._job_added = threading.Event()
             inst._protected = protected
             inst._queue_map = weakref.WeakKeyDictionary()
             cls._instances[thread] = inst
@@ -461,16 +461,18 @@ class Caller:
             self.iopub_sockets[self.thread] = socket
             task_status.started()
             while not self._stopped:
-                if not self._callers:
-                    self._callers_added.clear()
-                await wait_thread_event(self._callers_added)
-                while self._callers:
+                if not self._jobs:
+                    self._job_added.clear()
+                await wait_thread_event(self._job_added)
+                while self._jobs:
                     if self._stopped:
                         return
-                    job = self._callers.popleft()
+                    job = self._jobs.popleft()
                     if isinstance(job, Callable):
                         try:
-                            job()
+                            result = job()
+                            if inspect.iscoroutine(result):
+                                await result
                         except Exception as e:
                             self.log.exception("Simple call failed", exc_info=e)
                     else:
@@ -478,7 +480,7 @@ class Caller:
                         context.run(tg.start_soon, self._wrap_call, fut)
         finally:
             self._running = False
-            for job in self._callers:
+            for job in self._jobs:
                 if isinstance(job, tuple):
                     job[1].set_exception(FutureCancelledError())
             socket.close()
@@ -493,8 +495,8 @@ class Caller:
         if threading.current_thread() is self.thread and (tg := self._taskgroup):
             tg.start_soon(self._wrap_call, fut)
         else:
-            self._callers.append((contextvars.copy_context(), fut))
-            self._callers_added.set()
+            self._jobs.append((contextvars.copy_context(), fut))
+            self._job_added.set()
         return fut
 
     async def _wrap_call(self, fut: Future) -> None:
@@ -510,9 +512,11 @@ class Caller:
                 try:
                     if (delay := md.get("delay")) and ((delay := delay - time.monotonic() + md["start_time"]) > 0):
                         await anyio.sleep(delay)
-                    result = func(*md["args"], **md["kwargs"]) if callable(func) else func
-                    if inspect.isawaitable(result) and result is not fut:
+                    # Evaluate
+                    result = func(*md["args"], **md["kwargs"])
+                    if inspect.iscoroutine(result):
                         result = await result
+                    # Cancellation
                     if fut.cancelled() and not scope.cancel_called:
                         scope.cancel()
                     fut.set_result(result)
@@ -566,7 +570,7 @@ class Caller:
         for sender in self._queue_map.values():
             sender.close()
         self._queue_map.clear()
-        self._callers_added.set()
+        self._job_added.set()
         self._instances.pop(self.thread, None)
         if self in self._to_thread_pool:
             self._to_thread_pool.remove(self)
@@ -574,7 +578,12 @@ class Caller:
             self._stopped_event.wait()
 
     def call_later(
-        self, delay: float, func: Callable[P, T | Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs
+        self,
+        delay: float,
+        func: Callable[P, T | CoroutineType[Any, Any, T]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
     ) -> Future[T]:
         """
         Schedule func to be called in caller's event loop copying the current context.
@@ -587,7 +596,13 @@ class Caller:
         """
         return self._schedule_wrapped_call(func, args, kwargs, delay=delay, start_time=time.monotonic())
 
-    def call_soon(self, func: Callable[P, T | Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs) -> Future[T]:
+    def call_soon(
+        self,
+        func: Callable[P, T | CoroutineType[Any, Any, T]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Future[T]:
         """
         Schedule func to be called in caller's event loop copying the current context.
 
@@ -598,12 +613,18 @@ class Caller:
         """
         return self._schedule_wrapped_call(func, args, kwargs)
 
-    def call_direct(self, func: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs) -> None:
+    def call_direct(
+        self,
+        func: Callable[P, T | CoroutineType[Any, Any, T]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> None:
         """
         Schedule `func` to be called in caller's event loop directly.
 
         This method is provided to facilitate lightweight *thread-safe* function calls that
-        need to be done from within the callers event loop.
+        need to be performed from within the callers event loop/taskgroup.
 
         Args:
             func: The function (awaitables permitted, though discouraged).
@@ -612,11 +633,11 @@ class Caller:
 
         ??? warning
 
-            - Use this method for lightweight calls only.
-            - Corroutines will **not** be awaited.
+            **Use this method for lightweight calls only!**
+
         """
-        self._callers.append(functools.partial(func, *args, **kwargs))
-        self._callers_added.set()
+        self._jobs.append(functools.partial(func, *args, **kwargs))
+        self._job_added.set()
 
     def queue_exists(self, func: Callable) -> bool:
         "Returns True if an execution queue exists for `func`."
@@ -736,13 +757,24 @@ class Caller:
         raise RuntimeError(msg)
 
     @classmethod
-    def to_thread(cls, func: Callable[P, T | Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs) -> Future[T]:
+    def to_thread(
+        cls,
+        func: Callable[P, T | CoroutineType[Any, Any, T]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Future[T]:
         """A classmethod to call func in a separate thread see also [to_thread_by_name][async_kernel.Caller.to_thread_by_name]."""
         return cls.to_thread_by_name(None, func, *args, **kwargs)
 
     @classmethod
     def to_thread_by_name(
-        cls, name: str | None, func: Callable[P, T | Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs
+        cls,
+        name: str | None,
+        func: Callable[P, T | CoroutineType[Any, Any, T]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
     ) -> Future[T]:
         """
         A classmethod to call func in the thread specified by name.

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -11,7 +11,6 @@ import anyio
 import anyio.to_thread
 import pytest
 import sniffio
-from anyio.abc import TaskStatus
 
 from async_kernel.caller import (
     AsyncEvent,

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -172,7 +172,7 @@ class TestFuture:
 
     def test_repr(self):
         fut = Future(name="test", mydict={"test": "a long string" * 100})
-        assert repr(fut) == "Future< MainThread {'mydict': {…}, 'name': 'test'}>"
+        assert repr(fut) == "Future< MainThread {'mydict': {…}, 'name': 'test'} >"
 
 
 @pytest.mark.anyio
@@ -202,9 +202,13 @@ class TestCaller:
         b = {f"name {i}": "long_string" * 100 for i in range(100)}
         c = Future()
         c.metadata.update(a=a, b=b)
-        assert repr(c) == "Future< MainThread {'a': 'long stringl…nglong string', 'b': {…}}>"
+        assert repr(c) == "Future< MainThread {'a': 'long stringl…nglong string', 'b': {…}} >"
         fut = caller.call_soon(test_func, a, b, c)
-        assert repr(fut).startswith("Future< MainThread | <function TestCaller.test_repr.<locals>.test_func at")
+        assert repr(fut).startswith("Future< MainThread | <function")
+        await fut
+        assert repr(fut).startswith("Future< MainThread 🏁 | <function")
+        c.cancel()
+        assert repr(c) == "Future< MainThread ⛔ {'a': 'long stringl…nglong string', 'b': {…}} >"
 
     def test_no_thread(self):
         with pytest.raises(RuntimeError):
@@ -392,22 +396,16 @@ class TestCaller:
             with pytest.raises(RuntimeError):
                 await fut
 
-    async def test_as_completed_cancelled(self, anyio_backend):
+    async def test_as_completed_cancelled(self, caller):
         items = {Caller.to_thread(anyio.sleep, 100) for _ in range(4)}
-        async with Caller(create=True):
-
-            async def cancelled(task_status: TaskStatus[None]):
-                with pytest.raises(anyio.get_cancelled_exc_class()):  # noqa: PT012
-                    task_status.started()
-                    async for _ in Caller.as_completed(items):
-                        pass
-
-            async with anyio.create_task_group() as tg:
-                await tg.start(cancelled)
-                tg.cancel_scope.cancel()
-            for item in items:
-                with pytest.raises(FutureCancelledError):
-                    await item
+        with anyio.move_on_after(0.1):
+            with pytest.raises(anyio.get_cancelled_exc_class()):
+                async for _ in Caller.as_completed(items):
+                    pass
+        for item in items:
+            assert item.cancelled()
+            with pytest.raises(FutureCancelledError):
+                await item
 
     async def test__check_in_thread(self, anyio_backend):
         Caller.to_thread(anyio.sleep, 0.1)
@@ -438,7 +436,7 @@ class TestCaller:
             assert not caller.queue_exists(func)
 
     async def test_gc(self, anyio_backend):
-        event_finalize_called = AsyncEvent()
+        event_finalize_called = anyio.Event()
         async with Caller(create=True) as caller:
             weakref.finalize(caller, event_finalize_called.set)
             del caller
@@ -538,14 +536,11 @@ class TestCaller:
             await anyio.sleep(10)
             raise RuntimeError
 
-        async with anyio.create_task_group() as tg:
-            fut = caller.call_soon(async_func)
-            tg.start_soon(fut.wait)
-            await anyio.sleep(0)
-            tg.cancel_scope.cancel()
-        await anyio.sleep(0)
+        fut = caller.call_soon(async_func)
+        with anyio.move_on_after(0.1):
+            await fut
         with pytest.raises(FutureCancelledError):
-            fut.exception()  # pyright: ignore[reportPossiblyUnboundVariable]
+            fut.exception()
 
     @pytest.mark.parametrize("return_when", ["FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED"])
     async def test_wait(self, caller: Caller, return_when):


### PR DESCRIPTION
Caller.call_## methods will now only await func results that are coroutines.
call_direct will now also await results that are coroutines.