### PR TITLE
Put _send_reply back inside run_handler.

### DIFF
--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -848,33 +848,32 @@ class Kernel(HasTraits):
         This method gets called for every valid request with the relevant handler.
         """
 
+        def send_reply(job: Job[dict], content: dict, /) -> None:
+            if "status" not in content:
+                content["status"] = "ok"
+            msg = self.session.send(
+                stream=job["socket"],
+                msg_or_type=job["msg"]["header"]["msg_type"].replace("request", "reply"),
+                content=content,
+                parent=job["msg"]["header"],  # pyright: ignore[reportArgumentType]
+                ident=job["ident"],
+            )
+            if msg:
+                self.log.debug("*** _send_reply %s*** %s", job["socket_id"], msg)
+
         token = utils._job_var.set(job)  # pyright: ignore[reportPrivateUsage]
         try:
             self.iopub_send(msg_or_type="status", content={"execution_state": "busy"}, ident=self.topic("status"))
             if (content := await handler(job)) is not None:
-                self._send_reply(job, content)
+                send_reply(job, content)
         except Exception as e:
-            self._send_reply(job, error_to_content(e))
+            send_reply(job, error_to_content(e))
             self.log.exception("Exception in message handler:", exc_info=e)
         finally:
             utils._job_var.reset(token)  # pyright: ignore[reportPrivateUsage]
             self.iopub_send(
                 msg_or_type="status", parent=job["msg"], content={"execution_state": "idle"}, ident=self.topic("status")
             )
-
-    def _send_reply(self, job: Job[dict], content: dict, /) -> None:
-        """Send a reply to the job with the specified content."""
-        if "status" not in content:
-            content["status"] = "ok"
-        msg = self.session.send(
-            stream=job["socket"],
-            msg_or_type=job["msg"]["header"]["msg_type"].replace("request", "reply"),
-            content=content,
-            parent=job["msg"]["header"],  # pyright: ignore[reportArgumentType]
-            ident=job["ident"],
-        )
-        if msg:
-            self.log.debug("*** _send_reply %s*** %s", job["socket_id"], msg)
 
     def iopub_send(
         self,


### PR DESCRIPTION
`send_reply` should not be externally accessible even as a 'private' function.