### PR TITLE
Provide async line magic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The kernel provides two external interfaces:
 
 - [IPython shell](https://ipython.readthedocs.io/en/stable/overview.html#enhanced-interactive-python-shell)
     - top-level await ('asyncio' or 'trio' backend) in cells
+    - async magic function support in cells
 - [anyio](https://pypi.org/project/anyio/) compatible asynchronous backend ([`asyncio`](https://docs.python.org/3/library/asyncio.html) (default) or [`trio`](https://pypi.org/project/trio/))
 - [aiologic](https://aiologic.readthedocs.io/latest/) thread-safe synchronisation primitives
 - [Backend agnostic multi-thread / multi-event loop management](https://fleming79.github.io/async-kernel/latest/reference/caller/#async_kernel.caller.Caller)
@@ -34,6 +35,7 @@ The kernel provides two external interfaces:
     - [x] qt host and asyncio[^2] or trio[^3] backend running as a guest
 - [Experimental](https://github.com/fleming79/echo-kernel) support for
   [Jupyterlite](https://github.com/jupyterlite/jupyterlite) (try it online [here](https://fleming79.github.io/echo-kernel/) 👈)
+    - `%pip install` magic (using micropip)
 - [Debugger client](https://jupyterlab.readthedocs.io/en/latest/user/debugger.html#debugger)
 
 [^1]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ uvloop = ["uvloop; python_version <= '3.13' and sys_platform != 'win32' and impl
 dev = [
   "debugpy",
   "ipykernel; implementation_name == 'cpython'",
+  "pip; implementation_name == 'cpython'",
   {include-group = "uvloop"},
   {include-group = "test"},
 ]

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -329,11 +329,6 @@ class AsyncInteractiveShell(InteractiveShell):
     def ns_table(self) -> dict[str, dict[Any, Any] | dict[str, Any]]:
         return {"user_global": self.user_global_ns, "user_local": self.user_ns, "builtin": builtins.__dict__}
 
-    @override
-    def transform_cell(self, raw_cell: str) -> str:
-        cell = super().transform_cell(raw_cell)
-        return cell.replace("get_ipython().run_line_magic(", "await get_ipython().run_line_magic_async(")
-
     async def run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> Any:
         "Call and awaits [run_line_magic][IPython.core.interactiveshell.InteractiveShell.run_line_magic]."
         result = self.run_line_magic(magic_name, line, _stack_depth)
@@ -400,7 +395,9 @@ class AsyncInteractiveShell(InteractiveShell):
                             raw_cell=code,
                             store_history=store_history,
                             silent=silent,
-                            transformed_cell=self.transform_cell(code),
+                            transformed_cell=self.transform_cell(code).replace(
+                                "get_ipython().run_line_magic(", "await get_ipython().run_line_magic_async("
+                            ),
                             shell_futures=True,
                             cell_id=cell_id,
                         )

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -320,6 +320,17 @@ class AsyncInteractiveShell(InteractiveShell):
     def ns_table(self) -> dict[str, dict[Any, Any] | dict[str, Any]]:
         return {"user_global": self.user_global_ns, "user_local": self.user_ns, "builtin": builtins.__dict__}
 
+    @override
+    def transform_cell(self, raw_cell: str) -> str:
+        cell = super().transform_cell(raw_cell)
+        return cell.replace("get_ipython().run_line_magic(", "await get_ipython()._run_line_magic_async(")
+
+    async def _run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> None:
+        try:
+            await self.run_line_magic(magic_name, line, _stack_depth)  # pyright: ignore[reportGeneralTypeIssues]
+        except TypeError:
+            pass
+
     async def _execute_request(
         self,
         code: str = "",
@@ -773,6 +784,31 @@ class KernelMagics(Magics):
             f"\t----- {len(subshells)} x subshell -----\n" + "\n".join(subshells) if subshells else "-- No subshells --"
         )
         print(f"Current shell:\t{self.shell}\n\n{subshell_list}")
+
+    @line_magic
+    async def pip(self, line: str) -> None:
+        """Run the pip package manager within the current kernel.
+
+        Usage:
+          %pip install [pkgs]
+        """
+        if sys.platform == "emscripten":
+            import micropip  # noqa: PLC0415
+
+            await micropip.install(line.strip().removeprefix("install").strip(), verbose=True)
+        else:
+            await anyio.run_process([sys.executable, "-m", "pip", *line.split()])
+            print("Note: you may need to restart the kernel to use updated packages.")
+
+    @line_magic
+    async def uv(self, line):
+        """Run the uv package manager within the current kernel.
+
+        Usage:
+          %uv pip install [pkgs]
+        """
+        await anyio.run_process(["uv", *line.split()])
+        print("Note: you may need to restart the kernel to use updated packages.")
 
 
 InteractiveShellABC.register(AsyncInteractiveShell)

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -168,6 +168,7 @@ class AsyncInteractiveShell(InteractiveShell):
     Notable differences:
         - Supports a soft timeout specified via tags `timeout=<value in seconds>`[^1].
         - `user_ns` and `user_global_ns` are same dictionary which is a fixed [dict][].
+        - Supports async magic functions (See [KernelMagics.pip][]).
 
         [^1]: When the execution time exceeds the timeout value, the code execution will "move on".
     """
@@ -787,7 +788,7 @@ class KernelMagics(Magics):
 
     @line_magic
     async def pip(self, line: str) -> None:
-        """Run the pip package manager within the current kernel.
+        """Run the pip package manager for the current environment.
 
         Usage:
           %pip install [pkgs]
@@ -813,7 +814,7 @@ class KernelMagics(Magics):
 
     @line_magic
     async def uv(self, line):
-        """Run the uv package manager within the current kernel.
+        """Run the uv package manager for the current environment.
 
         Usage:
           %uv pip install [pkgs]

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -799,7 +799,10 @@ class KernelMagics(Magics):
 
             match line.split(maxsplit=1)[0]:
                 case "install":
-                    await micropip.install(line.removeprefix("install").split(), verbose=True)
+                    requirements = [
+                        f"emfs:{n}" if n.startswith(".") else n for n in line.removeprefix("install").split()
+                    ]
+                    await micropip.install(requirements, verbose=True)
                 case "uninstall":
                     micropip.uninstall(line.removeprefix("uninstall").split(), verbose=True)
                 case "freeze":

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -46,11 +46,11 @@ if TYPE_CHECKING:
 __all__ = ["AsyncInteractiveShell"]
 
 
-async def _transport_to_std(transport_stream: ByteReceiveStream, std: TextIO) -> None:
+async def _forward_transport_stream(transport_stream: ByteReceiveStream, out: TextIO, /) -> None:
     from anyio.streams.text import TextReceiveStream  # noqa: PLC0415
 
     async for text in TextReceiveStream(transport_stream):
-        std.write(text)
+        out.write(text)
 
 
 class AsyncDisplayHook(DisplayHook):
@@ -824,9 +824,9 @@ class KernelMagics(Magics):
             cmd = [sys.executable, "-m", "pip", *line.split()]
             async with await anyio.open_process(cmd) as process, anyio.create_task_group() as tg:
                 if process.stdout:
-                    tg.start_soon(_transport_to_std, process.stdout, sys.stdout)
+                    tg.start_soon(_forward_transport_stream, process.stdout, sys.stdout)
                 if process.stderr:
-                    tg.start_soon(_transport_to_std, process.stderr, sys.stderr)
+                    tg.start_soon(_forward_transport_stream, process.stderr, sys.stderr)
 
         return None
 
@@ -840,9 +840,9 @@ class KernelMagics(Magics):
         cmd = ["uv", *line.split()]
         async with await anyio.open_process(cmd) as process, anyio.create_task_group() as tg:
             if process.stdout:
-                tg.start_soon(_transport_to_std, process.stdout, sys.stdout)
+                tg.start_soon(_forward_transport_stream, process.stdout, sys.stdout)
             if process.stderr:
-                tg.start_soon(_transport_to_std, process.stderr, sys.stdout)
+                tg.start_soon(_forward_transport_stream, process.stderr, sys.stdout)
 
 
 InteractiveShellABC.register(AsyncInteractiveShell)

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -326,11 +326,12 @@ class AsyncInteractiveShell(InteractiveShell):
         cell = super().transform_cell(raw_cell)
         return cell.replace("get_ipython().run_line_magic(", "await get_ipython()._run_line_magic_async(")
 
-    async def _run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> None:
+    async def _run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> Any:
+        result = self.run_line_magic(magic_name, line, _stack_depth)
         try:
-            await self.run_line_magic(magic_name, line, _stack_depth)  # pyright: ignore[reportGeneralTypeIssues]
+            return await result  # pyright: ignore[reportGeneralTypeIssues]
         except TypeError:
-            pass
+            return result
 
     async def _execute_request(
         self,
@@ -787,7 +788,7 @@ class KernelMagics(Magics):
         print(f"Current shell:\t{self.shell}\n\n{subshell_list}")
 
     @line_magic
-    async def pip(self, line: str) -> None:
+    async def pip(self, line: str) -> Any | None:
         """Run the pip package manager for the current environment.
 
         Usage:
@@ -795,25 +796,25 @@ class KernelMagics(Magics):
         """
         if sys.platform == "emscripten":
             import micropip  # noqa: PLC0415
-            from IPython.display import display  # noqa: PLC0415
 
             match line.split(maxsplit=1)[0]:
                 case "install":
                     requirements = [
                         f"emfs:{n}" if n.startswith(".") else n for n in line.removeprefix("install").split()
                     ]
-                    await micropip.install(requirements, verbose=True)
+                    return await micropip.install(requirements, verbose=True)
                 case "uninstall":
-                    micropip.uninstall(line.removeprefix("uninstall").split(), verbose=True)
+                    return micropip.uninstall(line.removeprefix("uninstall").split(), verbose=True)
                 case "freeze":
-                    display(micropip.freeze())
+                    return micropip.freeze()
                 case "list":
-                    display(micropip.list())
+                    return micropip.list()
                 case _ as name:
                     print("Unsupported command:", name)
         else:
             await anyio.run_process([sys.executable, "-m", "pip", *line.split()])
             print("Note: you may need to restart the kernel to use updated packages.")
+        return None
 
     @line_magic
     async def uv(self, line):

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -794,8 +794,19 @@ class KernelMagics(Magics):
         """
         if sys.platform == "emscripten":
             import micropip  # noqa: PLC0415
+            from IPython.display import display  # noqa: PLC0415
 
-            await micropip.install(line.strip().removeprefix("install").strip(), verbose=True)
+            match line.split(maxsplit=1)[0]:
+                case "install":
+                    await micropip.install(line.removeprefix("install").split(), verbose=True)
+                case "uninstall":
+                    micropip.uninstall(line.removeprefix("uninstall").split(), verbose=True)
+                case "freeze":
+                    display(micropip.freeze())
+                case "list":
+                    display(micropip.list())
+                case _ as name:
+                    print("Unsupported command:", name)
         else:
             await anyio.run_process([sys.executable, "-m", "pip", *line.split()])
             print("Note: you may need to restart the kernel to use updated packages.")

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -8,7 +8,7 @@ import pathlib
 import sys
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, Self, overload
+from typing import TYPE_CHECKING, Any, Literal, Self, TextIO, overload
 
 import anyio
 import IPython.core.release
@@ -37,12 +37,20 @@ from async_kernel.typing import Channel, Content, Message, NoValue, Tags
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
+    from anyio.abc import ByteReceiveStream
     from traitlets.config import Configurable
 
     from async_kernel import Kernel
 
 
 __all__ = ["AsyncInteractiveShell"]
+
+
+async def _transport_to_std(transport_stream: ByteReceiveStream, std: TextIO) -> None:
+    from anyio.streams.text import TextReceiveStream  # noqa: PLC0415
+
+    async for text in TextReceiveStream(transport_stream):
+        std.write(text)
 
 
 class AsyncDisplayHook(DisplayHook):
@@ -812,19 +820,28 @@ class KernelMagics(Magics):
                 case _ as name:
                     print("Unsupported command:", name)
         else:
-            await anyio.run_process([sys.executable, "-m", "pip", *line.split()])
-            print("Note: you may need to restart the kernel to use updated packages.")
+            cmd = [sys.executable, "-m", "pip", *line.split()]
+            async with await anyio.open_process(cmd) as process, anyio.create_task_group() as tg:
+                if process.stdout:
+                    tg.start_soon(_transport_to_std, process.stdout, sys.stdout)
+                if process.stderr:
+                    tg.start_soon(_transport_to_std, process.stderr, sys.stderr)
+
         return None
 
     @line_magic
-    async def uv(self, line):
+    async def uv(self, line) -> None:
         """Run the uv package manager for the current environment.
 
         Usage:
           %uv pip install [pkgs]
         """
-        await anyio.run_process(["uv", *line.split()])
-        print("Note: you may need to restart the kernel to use updated packages.")
+        cmd = ["uv", *line.split()]
+        async with await anyio.open_process(cmd) as process, anyio.create_task_group() as tg:
+            if process.stdout:
+                tg.start_soon(_transport_to_std, process.stdout, sys.stdout)
+            if process.stderr:
+                tg.start_soon(_transport_to_std, process.stderr, sys.stdout)
 
 
 InteractiveShellABC.register(AsyncInteractiveShell)

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -332,9 +332,10 @@ class AsyncInteractiveShell(InteractiveShell):
     @override
     def transform_cell(self, raw_cell: str) -> str:
         cell = super().transform_cell(raw_cell)
-        return cell.replace("get_ipython().run_line_magic(", "await get_ipython()._run_line_magic_async(")
+        return cell.replace("get_ipython().run_line_magic(", "await get_ipython().run_line_magic_async(")
 
-    async def _run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> Any:
+    async def run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> Any:
+        "Call and awaits [run_line_magic][IPython.core.interactiveshell.InteractiveShell.run_line_magic]."
         result = self.run_line_magic(magic_name, line, _stack_depth)
         try:
             return await result  # pyright: ignore[reportGeneralTypeIssues]

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -440,6 +440,12 @@ async def test_magic(client: AsyncKernelClient, code: str, kernel: Kernel, monke
     assert stdout
 
 
+@pytest.mark.parametrize("code", argvalues=["%connect_info"])
+async def test_magic_sync(client: AsyncKernelClient, code: str, kernel: Kernel, monkeypatch):
+    result = kernel.main_shell.run_cell(code)
+    assert result.success
+
+
 async def test_shell_enable_gui(kernel: Kernel):
     # used by ipython AutoMagicChecker via is_shadowed (requires 'builitin')
     assert set(kernel.shell.ns_table) == {"user_global", "user_local", "builtin"}

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -420,7 +420,16 @@ async def test_debug_static_richInspectVariables(client: AsyncKernelClient, vari
     assert reply["content"]["status"] == "ok"
 
 
-@pytest.mark.parametrize("code", argvalues=["%connect_info", "%callers", "%subshell"])
+@pytest.mark.parametrize(
+    "code",
+    argvalues=[
+        "%connect_info",
+        "%callers",
+        "%subshell",
+        "%pip install anyio",
+        "%uv pip install anyio",
+    ],
+)
 async def test_magic(client: AsyncKernelClient, code: str, kernel: Kernel, monkeypatch):
     await utils.clear_iopub(client)
     monkeypatch.setenv("JUPYTER_RUNTIME_DIR", str(pathlib.Path(kernel.connection_file).parent))

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,7 @@ dependencies = [
 dev = [
     { name = "debugpy" },
     { name = "ipykernel", marker = "implementation_name == 'cpython'" },
+    { name = "pip", marker = "implementation_name == 'cpython'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -212,6 +213,7 @@ requires-dist = [
 dev = [
     { name = "debugpy" },
     { name = "ipykernel", marker = "implementation_name == 'cpython'" },
+    { name = "pip", marker = "implementation_name == 'cpython'" },
     { name = "pytest", specifier = ">=8.4,<9" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock" },
@@ -2126,7 +2128,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2218,6 +2220,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- magics written as coroutines or that return awaitables are awaited in execute requests.
- pip and uv magics are written as coroutines which get run in a subprocess. [micropip](https://micropip.pyodide.org/en/stable/project/api.html#micropip.install) is used on pyodide.