### PR TITLE
BaseKernelInterface refactoring

### DIFF
--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -94,13 +94,16 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
 
     host = None
 
-    run_in_shell_thread = traitlets.List(
+    handle_in_shell_thread = traitlets.List(
         traitlets.UseEnum(MsgType), [MsgType.comm_msg, MsgType.comm_open, MsgType.comm_close]
     )
     """
-    Message types that are handled in the shell's thread (typically the _MainThread_).
+    A list of `MsgType` that are always handled in the shell's thread (typically the _MainThread_).
+    """
 
-    All other shell message types are handled in the control thread.
+    handle_in_thread = traitlets.Dict(key_trait=traitlets.UseEnum(MsgType), value_trait=traitlets.Unicode())
+    """
+    A mapping of `MsgType` to the name of a separate caller (thread) in which to run the handler.
     """
 
     _zmq_context = None
@@ -112,6 +115,14 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
     @traitlets.default("log")
     def _default_log(self) -> LoggerAdapter[Logger]:
         return logging.LoggerAdapter(logging.getLogger(self.__class__.__name__))
+
+    @traitlets.default("handle_in_thread")
+    def _default_handle_in_thread(self) -> dict[MsgType, str]:
+        return {
+            MsgType.inspect_request: "language_server",
+            MsgType.complete_request: "language_server",
+            MsgType.is_complete_request: "language_server",
+        }
 
     def __init__(self, kernel_settings: dict[str, Any] | None = None, /) -> None:
         if self.kernel.trait_has_value("interface"):
@@ -159,16 +170,6 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
                     restore_io()
                 self._handler_cache.clear()
                 gc.collect()
-
-    def stop(self) -> None:
-        """
-        Stop the kernel.
-        """
-        if scope := getattr(self, "_scope", None):
-            del self._scope
-            self.kernel.log.info("Stopping kernel: %s", self.kernel)
-            self.callers[Channel.shell].call_direct(scope.cancel, "Stopping kernel")
-            self.kernel.event_stopped.set()
 
     @enable_signal_safety
     def _signal_handler(self, signum, frame: FrameType | None) -> None:
@@ -283,28 +284,26 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
 
         run_mode = RunMode.queue
         msg_type = MsgType(job["msg"]["header"]["msg_type"])
-        channel: Literal[Channel.shell, Channel.control] = job["msg"]["channel"]  # pyright: ignore[reportAssignmentType]
-        caller = self.callers[channel]
 
-        match msg_type:
-            case MsgType.execute_request:
-                if content := job["msg"].get("content", {}):
-                    if (code := content.get("code")) and (
-                        mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
-                    ):
-                        run_mode = mode
-                    if content.get("silent"):
-                        run_mode = RunMode.task
-                try:
-                    run_mode = next(mode for tag in utils.get_tags(job) if (mode := RunMode.to_runmode(tag)))
-                except Exception:
-                    pass
-            case MsgType.inspect_request:
-                caller = caller.get(name=f"kernel: {msg_type=}", no_debug=True)
-            case self.run_in_shell_thread:
-                caller = self.callers[Channel.control]
-            case _:
+        if msg_type is MsgType.execute_request:
+            caller = self.callers[job["msg"]["channel"]]  # pyright: ignore[reportArgumentType]
+            if content := job["msg"].get("content", {}):
+                if (code := content.get("code")) and (
+                    mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
+                ):
+                    run_mode = mode
+                if content.get("silent"):
+                    run_mode = RunMode.task
+            try:
+                run_mode = next(mode for tag in utils.get_tags(job) if (mode := RunMode.to_runmode(tag)))
+            except Exception:
                 pass
+        elif msg_type in self.handle_in_shell_thread:
+            caller = self.callers[Channel.shell]
+        else:
+            caller = self.callers[Channel.control]
+            if thread_name := self.handle_in_thread.get(msg_type):
+                caller = caller.get(name=thread_name, no_debug=True)
 
         match run_mode:
             case RunMode.queue:
@@ -315,6 +314,32 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
                 caller.to_thread(handler, job)
 
         self.log.debug("%s %s %s %s", msg_type, run_mode, handler, job)
+
+    async def run(self, *, stopped: Callable[[], Any] | None = None) -> None:
+        """
+        Run the kernel.
+
+        Args:
+            stopped: An optional callback that is called when the kernel has stopped.
+
+        This method requires that a [Caller][async_kernel.caller.Caller] instance does not already exist in the current thread.
+        """
+        try:
+            async with self as kernel:
+                await kernel.event_stopped
+        finally:
+            if stopped:
+                stopped()
+
+    def stop(self) -> None:
+        """
+        Stop the kernel.
+        """
+        if scope := getattr(self, "_scope", None):
+            del self._scope
+            self.kernel.log.info("Stopping kernel: %s", self.kernel)
+            self.callers[Channel.shell].call_direct(scope.cancel, "Stopping kernel")
+            self.kernel.event_stopped.set()
 
     def input_request(self, prompt: str, *, password: bool = False) -> str:
         """
@@ -412,19 +437,3 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
     ) -> None:
         """Send an iopub message."""
         raise NotImplementedError
-
-    async def run(self, *, stopped: Callable[[], Any] | None = None) -> None:
-        """
-        Run the kernel.
-
-        Args:
-            stopped: An optional callback that is called when the kernel has stopped.
-
-        This method requires that a [Caller][async_kernel.caller.Caller] instance does not already exist in the current thread.
-        """
-        try:
-            async with self as kernel:
-                await kernel.event_stopped
-        finally:
-            if stopped:
-                stopped()

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -95,7 +95,7 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
     host = None
 
     run_in_shell_thread = traitlets.List(
-        traitlets.UseEnum(MsgType), [MsgType.execute_request, MsgType.comm_msg, MsgType.comm_open, MsgType.comm_close]
+        traitlets.UseEnum(MsgType), [MsgType.comm_msg, MsgType.comm_open, MsgType.comm_close]
     )
     """
     Message types that are handled in the shell's thread (typically the _MainThread_).
@@ -207,6 +207,114 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
             setattr(sys, name, wrapper)
 
         return restore
+
+    def _get_handler(self, job: Job, send_reply: Callable[[Job, dict], CoroutineType[Any, Any, None]]) -> HandlerType:
+        try:
+            subshell_id = job["msg"]["content"]["subshell_id"]
+        except KeyError:
+            try:
+                subshell_id = job["msg"]["header"]["subshell_id"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            except KeyError:
+                subshell_id = None
+        msg_type = MsgType(job["msg"]["header"]["msg_type"])
+
+        if msg_type is MsgType.execute_request:
+            key = (subshell_id, msg_type, send_reply)
+        else:
+            key = (None, msg_type, send_reply)
+        try:
+            return self._handler_cache[key]
+        except KeyError:
+            handler: HandlerType = getattr(self.kernel, msg_type)
+
+            @functools.wraps(handler)
+            async def run_handler(job: Job) -> None:
+                job_token = utils._job_var.set(job)  # pyright: ignore[reportPrivateUsage]
+                subshell_token = ShellPendingManager._id_contextvar.set(subshell_id)  # pyright: ignore[reportPrivateUsage]
+
+                try:
+                    self.iopub_send(
+                        msg_or_type="status",
+                        parent=job["msg"],
+                        content={"execution_state": "busy"},
+                        ident=b"kernel.status",
+                    )
+                    if (content := await handler(job)) is not None:
+                        await send_reply(job, content)
+                except Exception as e:
+                    await send_reply(job, utils.error_to_content(e))
+                    self.log.exception("Exception in message handler:", exc_info=e)
+                finally:
+                    utils._job_var.reset(job_token)  # pyright: ignore[reportPrivateUsage]
+                    ShellPendingManager._id_contextvar.reset(subshell_token)  # pyright: ignore[reportPrivateUsage]
+                    self.iopub_send(
+                        msg_or_type="status",
+                        parent=job["msg"],
+                        content={"execution_state": "idle"},
+                        ident=b"kernel.status",
+                    )
+                    del job
+
+            self._handler_cache[key] = run_handler
+            return run_handler
+
+    def message_handler(self, job: Job, send_reply: Callable[[Job, dict], CoroutineType[Any, Any, None]], /) -> None:
+        """
+        Schedule handling of the job (msg) with a handler running in a Task managed by a Caller.
+
+        Each `msg_type` runs in a separate task, possibly in a separate thread and event loop.
+        Typically, jobs are queued for execution by either the 'shell' or 'control' caller using
+        [queue_call][async_kernel.caller.Caller.queue_call].
+
+        'execute_request' messages can also specify alternate run modes:
+            - task: Run the execute request as a task.
+            - thread: Run the execute request in a worker thread.
+
+            The alternate run mode can be specified in a few ways:
+            - as a comment on the first line of the code block `# task` or `# thread`.
+            - As a tag `thread` or `task`
+
+        Args:
+            job: A dict with the msg and supporting details.
+            send_reply: The function for the handler to use to send the reply to the message.
+        """
+
+        handler = self._get_handler(job, send_reply)
+
+        run_mode = RunMode.queue
+        msg_type = MsgType(job["msg"]["header"]["msg_type"])
+        channel: Literal[Channel.shell, Channel.control] = job["msg"]["channel"]  # pyright: ignore[reportAssignmentType]
+        caller = self.callers[channel]
+
+        match msg_type:
+            case MsgType.execute_request:
+                if content := job["msg"].get("content", {}):
+                    if (code := content.get("code")) and (
+                        mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
+                    ):
+                        run_mode = mode
+                    if content.get("silent"):
+                        run_mode = RunMode.task
+                try:
+                    run_mode = next(mode for tag in utils.get_tags(job) if (mode := RunMode.to_runmode(tag)))
+                except Exception:
+                    pass
+            case MsgType.inspect_request:
+                caller = caller.get(name=f"kernel: {msg_type=}", no_debug=True)
+            case self.run_in_shell_thread:
+                caller = self.callers[Channel.control]
+            case _:
+                pass
+
+        match run_mode:
+            case RunMode.queue:
+                caller.queue_call(handler, job)
+            case RunMode.task:
+                caller.call_soon(handler, job)
+            case RunMode.thread:
+                caller.to_thread(handler, job)
+
+        self.log.debug("%s %s %s %s", msg_type, run_mode, handler, job)
 
     def input_request(self, prompt: str, *, password: bool = False) -> str:
         """
@@ -320,132 +428,3 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
         finally:
             if stopped:
                 stopped()
-
-    def message_handler(
-        self,
-        channel: Literal[Channel.shell, Channel.control],
-        msg_type: MsgType,
-        job: Job,
-        send_reply: Callable[[Job, dict], CoroutineType[Any, Any, None]],
-        /,
-    ) -> None:
-        """
-        Schedule handling of the job with a handler running in a Task.
-
-        Each `msg_type` runs in a separate task, possibly in a separate thread and event loop.
-        Typically, jobs are queued for execution by either the 'shell' or 'control' caller using `queue_call`.
-
-        'execute_request' messages can also specify alternate run modes:
-            - task: Run the execute request as a task.
-            - thread: Run the execute request in a worker thread.
-
-            The alternate run mode can be specified in a few ways:
-            - as a comment on the first line of the code block `# task` or `# thread`.
-            - As a tag `thread` or `task`
-
-        Args:
-            channel: The channel the message arrived on.
-            msg_type: The type of msg.
-            job: A dict with the msg and supporting details.
-            send_reply: The function for the handler to use to send the reply to the message.
-        """
-        # Note: There are never any active pending trackers in this context.
-        try:
-            subshell_id = job["msg"]["content"]["subshell_id"]
-        except KeyError:
-            try:
-                subshell_id = job["msg"]["header"]["subshell_id"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
-            except KeyError:
-                subshell_id = None
-        handler = self.get_handler(subshell_id, msg_type, send_reply)
-        run_mode = self.get_run_mode(msg_type, job)
-        caller = self.callers[channel]
-        if channel is Channel.shell and msg_type not in self.run_in_shell_thread:
-            caller = self.callers[Channel.control]
-        # Schedule job
-        match run_mode:
-            case RunMode.queue:
-                caller.queue_call(handler, job)
-            case RunMode.task:
-                caller.call_soon(handler, job)
-            case RunMode.thread:
-                caller.to_thread(handler, job)
-        self.log.debug("%s %s %s %s %s", channel, msg_type, run_mode, handler, job)
-
-    def get_handler(
-        self,
-        subshell_id: str | None,
-        msg_type: MsgType,
-        send_reply: Callable[[Job, dict], CoroutineType[Any, Any, None]],
-    ) -> HandlerType:
-        """
-        Returns a function to run the kernel handler for the corresponding `msg_type`.
-
-        The function is cached by `(subshell_id or None, msg_type, send_reply)` and is responsible
-        for publishing 'busy' and 'idle' messages plus sending the reply.
-
-        Args:
-            subshell_id: The id of an existing subshell.
-            msg_type: The Kernel `msg_type`.
-            send_reply: The function for the handler to use to send the reply.
-        """
-        if msg_type is MsgType.execute_request:
-            key = (subshell_id, msg_type, send_reply)
-        else:
-            key = (None, msg_type, send_reply)
-        try:
-            return self._handler_cache[key]
-        except KeyError:
-            handler: HandlerType = getattr(self.kernel, msg_type)
-
-            @functools.wraps(handler)
-            async def run_handler(job: Job) -> None:
-                job_token = utils._job_var.set(job)  # pyright: ignore[reportPrivateUsage]
-                subshell_token = ShellPendingManager._id_contextvar.set(subshell_id)  # pyright: ignore[reportPrivateUsage]
-
-                try:
-                    self.iopub_send(
-                        msg_or_type="status",
-                        parent=job["msg"],
-                        content={"execution_state": "busy"},
-                        ident=b"kernel.status",
-                    )
-                    if (content := await handler(job)) is not None:
-                        await send_reply(job, content)
-                except Exception as e:
-                    await send_reply(job, utils.error_to_content(e))
-                    self.log.exception("Exception in message handler:", exc_info=e)
-                finally:
-                    utils._job_var.reset(job_token)  # pyright: ignore[reportPrivateUsage]
-                    ShellPendingManager._id_contextvar.reset(subshell_token)  # pyright: ignore[reportPrivateUsage]
-                    self.iopub_send(
-                        msg_or_type="status",
-                        parent=job["msg"],
-                        content={"execution_state": "idle"},
-                        ident=b"kernel.status",
-                    )
-                    del job
-
-            self._handler_cache[key] = run_handler
-            return run_handler
-
-    def get_run_mode(self, msg_type: MsgType, job: Job, /) -> RunMode:
-        """
-        Get the run mode for the job.
-        """
-        # TODO: Are any of these options worth including?
-        # if run_mode := job["msg"]["header"].get("run_mode"):
-        #     return RunMode(run_mode)
-        if msg_type is MsgType.execute_request:
-            if content := job["msg"].get("content", {}):
-                if (code := content.get("code")) and (
-                    mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
-                ):
-                    return mode
-                if content.get("silent"):
-                    return RunMode.task
-            try:
-                return next(mode for tag in utils.get_tags(job) if (mode := RunMode.to_runmode(tag)))
-            except Exception:
-                pass
-        return RunMode.queue

--- a/src/async_kernel/interface/callable.py
+++ b/src/async_kernel/interface/callable.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 import async_kernel
 from async_kernel.compat.json import pack_json_str, unpack_json
 from async_kernel.interface.base import BaseKernelInterface
-from async_kernel.typing import Channel, Content, Job, Message, MsgHeader, MsgType, NoValue
+from async_kernel.typing import Channel, Content, Job, Message, MsgHeader, NoValue
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -117,7 +117,7 @@ class CallableKernelInterface(BaseKernelInterface):
         msg["buffers"] = [b[:] for b in buffers] if buffers else []
         msg["channel"] = Channel(msg["channel"])
         job = Job(received_time=time.monotonic(), msg=msg, ident=b"")
-        self.message_handler(msg["channel"], MsgType(job["msg"]["header"]["msg_type"]), job, self._send_reply)  # pyright: ignore[reportArgumentType]
+        self.message_handler(job, self._send_reply)
 
     @override
     def iopub_send(

--- a/src/async_kernel/interface/zmq.py
+++ b/src/async_kernel/interface/zmq.py
@@ -33,7 +33,7 @@ from async_kernel import Kernel, utils
 from async_kernel.caller import Caller
 from async_kernel.common import Fixed, KernelInterrupt
 from async_kernel.interface.base import BaseKernelInterface
-from async_kernel.typing import Backend, Channel, Content, Hosts, Job, Message, MsgHeader, MsgType, NoValue, RunSettings
+from async_kernel.typing import Backend, Channel, Content, Hosts, Job, Message, MsgHeader, NoValue, RunSettings
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -447,7 +447,7 @@ class ZMQKernelInterface(BaseKernelInterface):
                     ident, msg = session.recv(socket, mode=zmq.BLOCKY, copy=False)
                     msg["channel"] = channel  # pyright: ignore[reportOptionalSubscript]
                     job = Job(received_time=time.monotonic(), msg=msg, ident=ident)  # pyright: ignore[reportArgumentType]
-                    message_handler(channel, MsgType(job["msg"]["header"]["msg_type"]), job, send_reply)
+                    message_handler(job, send_reply)
                 except zmq.ContextTerminated:
                     break
                 except Exception as e:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -13,7 +13,7 @@ from async_kernel import Kernel, Pending
 from async_kernel.asyncshell import AsyncInteractiveShell, AsyncInteractiveSubshell, SubshellManager
 from async_kernel.caller import Caller
 from async_kernel.comm import Comm
-from async_kernel.typing import Channel, ExecuteContent, Job, MsgType, RunMode, Tags
+from async_kernel.typing import Channel, MsgType, RunMode, Tags
 from tests import utils
 
 if TYPE_CHECKING:
@@ -494,27 +494,6 @@ async def test_invalid_message(client: AsyncKernelClient, channel: Literal[Chann
     f = utils.send_control_message if channel == "control" else utils.send_shell_message
     await f(client, "test_invalid_message", reply=False)  # pyright: ignore[reportArgumentType]
     await anyio.sleep(0.1)
-
-
-@pytest.mark.parametrize(
-    ("code", "silent", "expected"),
-    [
-        (f"{RunMode.task}", False, RunMode.task),
-        (f" {RunMode.task}", False, RunMode.task),
-        ("print(1)", False, RunMode.queue),
-        ("", True, RunMode.task),
-        (f"{RunMode.thread}\nprint('hello')", False, RunMode.thread),
-        ("", False, RunMode.queue),
-        ("threads", False, RunMode.queue),
-        ("Task", False, RunMode.queue),
-    ],
-)
-async def test_get_run_mode(kernel: Kernel, code: str, silent: bool, expected: RunMode, job: Job[ExecuteContent]):
-    job["msg"]["content"]["code"] = code
-    job["msg"]["content"]["silent"] = silent
-    msg_type = job["msg"]["header"]["msg_type"]
-    mode = kernel.interface.get_run_mode(msg_type, job)  # pyright: ignore[reportArgumentType]
-    assert mode is expected
 
 
 async def test_get_run_mode_tag(client: AsyncKernelClient):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -496,12 +496,21 @@ async def test_invalid_message(client: AsyncKernelClient, channel: Literal[Chann
     await anyio.sleep(0.1)
 
 
-async def test_get_run_mode_tag(client: AsyncKernelClient):
+async def test_run_mode_tag(client: AsyncKernelClient):
     metadata = {"tags": [RunMode.thread]}
     _, content = await utils.execute(
         client,
         "import threading;thread_name=threading.current_thread().name",
         metadata=metadata,
+        user_expressions={"thread_name": "thread_name"},
+    )
+    assert content["status"] == "ok"
+    assert "async_kernel_caller" in content["user_expressions"]["thread_name"]["data"]["text/plain"]
+
+async def test_get_run_mode_cell_top_line(client: AsyncKernelClient):
+    _, content = await utils.execute(
+        client,
+        "# thread\nimport threading;thread_name=threading.current_thread().name",
         user_expressions={"thread_name": "thread_name"},
     )
     assert content["status"] == "ok"

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -507,6 +507,7 @@ async def test_run_mode_tag(client: AsyncKernelClient):
     assert content["status"] == "ok"
     assert "async_kernel_caller" in content["user_expressions"]["thread_name"]["data"]["text/plain"]
 
+
 async def test_get_run_mode_cell_top_line(client: AsyncKernelClient):
     _, content = await utils.execute(
         client,


### PR DESCRIPTION
- Non-user breaking changes
    - Dropped BaseKernelInterface.get_run_mode
    - Changed signature of BaseKernelInterface.message_handler
    - Rename BaseKernelInterface.get_handler to BaseKernelInterface._get_handler
  - Added BaseKernelInterface.handle_in_thread