### PR TITLE
Support specifing the thread with cell magic and passing thread options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,5 +110,5 @@ jobs:
         timeout-minutes: 5
         run: |
           uv sync --group docs
-          uv run async-kernel -a async-docs --shell.timeout=0.1          
+          uv run async-kernel -a async-docs --shell.timeout=1
           uv run mkdocs build -s

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install the project
         run: |
           uv sync --group docs
-          uv run async-kernel -a async-docs --shell.timeout=0.1    # The 'async-docs' kernel is specified as the kernel for mkdocs-jupyter
+          uv run async-kernel -a async-docs --shell.timeout=1    # The 'async-docs' kernel is specified as the kernel for mkdocs-jupyter
 
       - name: Version info
         id: version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Additional steps to build documentation (optional):
 
 ```bash
 uv sync --group docs
-uv run async-kernel -a async-docs --main_shell.timeout=0.1
+uv run async-kernel -a async-docs --main_shell.timeout=1
 ```
 
 ### Running tests
@@ -100,7 +100,7 @@ The 'docs' group specified extra packages are required to build documentation.
 
 ```bash
 uv sync --group docs
-uv run async-kernel -a async-docs --main_shell.timeout=0.1
+uv run async-kernel -a async-docs --main_shell.timeout=1
 ```
 
 #### Test the docs
@@ -114,7 +114,7 @@ uv run mkdocs build -s
     The command:
 
     ```bash
-    uv run async-kernel -a async-docs --main_shell.timeout=0.1
+    uv run async-kernel -a async-docs --main_shell.timeout=1
     ```
 
     Defines a new kernel spec with the name "async-docs" that sets the `shell.timeout` to 100ms.

--- a/docs/notebooks/caller.ipynb
+++ b/docs/notebooks/caller.ipynb
@@ -233,7 +233,7 @@
    "source": [
     "## Caller methods that return Pending\n",
     "\n",
-    "Pending is like a thread-safe [asyncio.Future](https://docs.python.org/3/library/asyncio-future.html#asyncio.Future) like object to return future results. It was called `Pending` to avoid confusion about differences in functionality to that of `asyncio.Future` and `concurrent.futures.Future`.\n",
+    "Pending is a thread-safe representation of a future result. It was designed to provide thread-safe functionality similar [asyncio.Future](https://docs.python.org/3/library/asyncio-future.html#asyncio.Future) and was named `Pending` to avoid confusion about differences in functionality to that of `asyncio.Future` and `concurrent.futures.Future`.\n",
     "\n",
     "The following functions return a `Pending` object:\n",
     "\n",

--- a/docs/notebooks/concurrency.ipynb
+++ b/docs/notebooks/concurrency.ipynb
@@ -187,10 +187,7 @@
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    },
-    "tags": [
-     "suppress-error"
-    ]
+    }
    },
    "outputs": [],
    "source": [
@@ -223,13 +220,12 @@
      "slide_type": ""
     },
     "tags": [
-     "thread",
-     "suppress-error"
+     "thread"
     ]
    },
    "outputs": [],
    "source": [
-    "# This time we'll use the tag to run the cell in a Thread\n",
+    "# This time we'll use the tag to run the cell in a worker thread\n",
     "await demo()"
    ]
   },
@@ -248,6 +244,96 @@
    "source": [
     "# thread\n",
     "%callers # magic provided by async-kernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "We can also specify CallerCreateOptions as part of the top line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# thread name=\"My thread\"\n",
+    "%callers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Asynchronous magic\n",
+    "\n",
+    "Asynchronous line (%) and cell (%%) magic functions are supported.\n",
+    "\n",
+    "### thread magic\n",
+    "\n",
+    "This will run the code in a thread. When no settings are provided a cell worker thread is used.\n",
+    "\n",
+    "#### Comparing thread magic with thread run mode\n",
+    "\n",
+    "- thread magic (`%%thread`) is an asynchronous magic that executes the associated **code** in a separate thread. \n",
+    "- [thread run mode](#run-mode-thread) (`# thread`) instructs the kernel to run the **entire cell** in a separate thread, bypassing the shell execute request queue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the magic 'callers' in a caller worker thread.\n",
+    "%thread %callers "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "To specify a thread (caller) by name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%thread name=\"My executor\" \n",
+    "%callers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "Many of arguments accepted on `Caller.get` are also supported. Let's use a thread with a trio backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%thread name=\"My trio executor\" backend=trio\n",
+    "%callers\n",
+    "\n",
+    "import trio\n",
+    "await trio.sleep(0)"
    ]
   }
  ],

--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -19,7 +19,7 @@ from IPython.core.displaypub import DisplayPublisher
 from IPython.core.history import HistoryManager
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.interactiveshell import _modified_open as _modified_open_  # pyright: ignore[reportPrivateUsage]
-from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
+from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class, no_var_expand
 from IPython.utils.tokenutil import token_at_cursor
 from jupyter_core.paths import jupyter_runtime_dir
 from traitlets import traitlets
@@ -32,7 +32,7 @@ from async_kernel.common import Fixed, KernelInterrupt, import_item
 from async_kernel.compiler import XCachingCompiler
 from async_kernel.event_loop.run import get_runtime_matplotlib_guis
 from async_kernel.pending import PendingManager
-from async_kernel.typing import Channel, Content, Message, NoValue, Tags
+from async_kernel.typing import Channel, Content, Message, NoValue, RunMode, Tags
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -931,6 +931,7 @@ class KernelMagics(Magics):
         )
         print(f"Current shell:\t{self.shell}\n\n{subshell_list}")
 
+    @no_var_expand
     @line_magic
     async def pip(self, line: str) -> Any | None:
         """Run the pip package manager for the current environment.
@@ -965,6 +966,7 @@ class KernelMagics(Magics):
 
         return None
 
+    @no_var_expand
     @line_magic
     async def uv(self, line) -> None:
         """Run the uv package manager for the current environment.
@@ -979,16 +981,28 @@ class KernelMagics(Magics):
             if process.stderr:
                 tg.start_soon(_forward_transport_stream, process.stderr, sys.stdout)
 
+    @no_var_expand
     @line_cell_magic
-    async def python(self, line: str, cell: str) -> None:
+    async def thread(self, line: str, cell: str | None = None) -> None:
         """
-        Run python code.
+        Run the python code in a caller managed child thread.
 
-        Useful only when the primary language is not Python.
+        Both line and cell magic are supported.
+
+        For cell_magic, [CallerCreateOptions][async_kernel.typing.CallerCreateOptions] can be passed as literals.
+
+        Example:
+            %%thread name="Trio executor" backend=trio
         """
-        shell = SubshellManager.get_shell()
-        cell = cell or line
-        await shell.run_cell_async(
+        shell: AsyncInteractiveShell | AsyncInteractiveSubshell = SubshellManager.get_shell()
+        if cell is None:
+            cell = line
+            options: Any = None
+        else:
+            options = RunMode.line_to_options(line)
+        caller = shell.kernel.caller
+        await (caller.get(**options).call_soon if options else caller.to_thread)(
+            shell.run_cell_async,
             raw_cell=cell,
             store_history=False,
             silent=True,

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -28,6 +28,7 @@ from async_kernel.common import Fixed, KernelInterrupt
 from async_kernel.iostream import OutStream
 from async_kernel.typing import (
     Backend,
+    CallerCreateOptions,
     Channel,
     Content,
     HandlerType,
@@ -282,22 +283,22 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
 
         handler = self._get_handler(job, send_reply)
 
-        run_mode = RunMode.queue
+        run_mode: RunMode | CallerCreateOptions | None = None
         msg_type = MsgType(job["msg"]["header"]["msg_type"])
 
         if msg_type is MsgType.execute_request:
             caller = self.callers[job["msg"]["channel"]]  # pyright: ignore[reportArgumentType]
-            if content := job["msg"].get("content", {}):
-                if (code := content.get("code")) and (
-                    mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
-                ):
-                    run_mode = mode
-                if content.get("silent"):
-                    run_mode = RunMode.task
             try:
                 run_mode = next(mode for tag in utils.get_tags(job) if (mode := RunMode.to_runmode(tag)))
-            except Exception:
-                pass
+            except StopIteration:
+                if content := job["msg"].get("content", {}):
+                    if (code := content.get("code")) and (
+                        mode := RunMode.to_runmode(code.strip().split("\n", maxsplit=1)[0])
+                    ):
+                        run_mode = mode
+                    if content.get("silent"):
+                        run_mode = RunMode.task
+
         elif msg_type in self.handle_in_shell_thread:
             caller = self.callers[Channel.shell]
         else:
@@ -306,12 +307,14 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
                 caller = caller.get(name=thread_name, no_debug=True)
 
         match run_mode:
-            case RunMode.queue:
+            case RunMode.queue | None:
                 caller.queue_call(handler, job)
             case RunMode.task:
                 caller.call_soon(handler, job)
             case RunMode.thread:
                 caller.to_thread(handler, job)
+            case _ as options:
+                caller.get(**options).call_soon(handler, job)
 
         self.log.debug("%s %s %s %s", msg_type, run_mode, handler, job)
 

--- a/src/async_kernel/typing.py
+++ b/src/async_kernel/typing.py
@@ -4,7 +4,7 @@ import enum
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Generic, Literal, NotRequired, ParamSpec, Self, TypedDict, TypeVar
 
-from typing_extensions import Sentinel, override
+from typing_extensions import Sentinel, get_annotations, override
 
 if TYPE_CHECKING:
     import datetime
@@ -114,14 +114,44 @@ class RunMode(enum.StrEnum):
         return hash(self.name)
 
     @classmethod
-    def to_runmode(cls, value: Any, default: T = None, /) -> Self | T:
-        "Converts value to `Runmode` or default where it is not possible."
+    def to_runmode(cls, value: Any, default: T = None, /) -> Self | T | CallerCreateOptions:
+        """
+        Converts value to `Runmode`, `CallerCreateOptions` or  default where it is not possible.
+
+        `CallerCreateOptions` will only return when a string is passed specifying a thread and options.
+
+        Example:
+            `value = "# thread name='My exeecutor' backend=trio`
+        """
         try:
             return cls(value)
         except ValueError:
-            if isinstance(value, str) and value.startswith(("# ", "##")):
-                return cls.to_runmode(value[2:], default)
+            if isinstance(value, str):
+                if value.startswith(("# ", "##")):
+                    return cls.to_runmode(value[2:].strip(), default)
+                if value.startswith("thread"):
+                    return cls.line_to_options(value.removeprefix("thread"))
             return default
+
+    @classmethod
+    def line_to_options(cls, line: str, /) -> CallerCreateOptions:
+        "Convert the line string to CallerCreateOptions."
+        import shlex  # noqa: PLC0415
+
+        items = CallerCreateOptions()
+        for v in shlex.split(line):
+            k, val = v.split("=", maxsplit=1)
+            try:
+                items[k] = eval(val)
+            except Exception:
+                items[k] = val
+        if items and not items.get("name"):
+            msg = "'name' must be specified when providing settings!"
+            raise ValueError(msg)
+        if invalid := set(items).difference(get_annotations(CallerCreateOptions)):
+            msg = f"One or more invalid options found! valid={list(get_annotations(CallerCreateOptions))} invalid={list(invalid)}"
+            raise ValueError(msg)
+        return items
 
     queue = "queue"
     "Run the message handler using [async_kernel.caller.Caller.queue_call][]."

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -412,7 +412,8 @@ async def test_debug_static_richInspectVariables(client: AsyncKernelClient, vari
         "%subshell",
         "%pip install anyio",
         "%uv pip install anyio",
-        "%%python\nprint('hello')",
+        "%thread\nprint('okay')",
+        """%%thread name="Trio executor" backend=trio\nfrom async_kernel import Caller; assert Caller().name == "Trio executor";print('okay')""",
     ],
 )
 async def test_magic(client: AsyncKernelClient, code: str, kernel: Kernel, monkeypatch):
@@ -423,6 +424,15 @@ async def test_magic(client: AsyncKernelClient, code: str, kernel: Kernel, monke
     assert reply["status"] == "ok"
     stdout, _ = await utils.assemble_output(client)
     assert stdout
+
+
+async def test_magic_error(client: AsyncKernelClient):
+    _, reply = await utils.execute(client, "%%thread backend=trio\npass")
+    assert reply["status"] == "error"
+    assert "'name' must be specified when providing settings!" in reply["evalue"]
+    _, reply = await utils.execute(client, "%%thread name=test not_an_option=True\npass")
+    assert reply["status"] == "error"
+    assert "One or more invalid options found" in reply["evalue"]
 
 
 @pytest.mark.parametrize("code", argvalues=["%connect_info"])
@@ -508,7 +518,7 @@ async def test_run_mode_tag(client: AsyncKernelClient):
     assert "async_kernel_caller" in content["user_expressions"]["thread_name"]["data"]["text/plain"]
 
 
-async def test_get_run_mode_cell_top_line(client: AsyncKernelClient):
+async def test_cell_top_line_to_thread(client: AsyncKernelClient):
     _, content = await utils.execute(
         client,
         "# thread\nimport threading;thread_name=threading.current_thread().name",
@@ -516,6 +526,16 @@ async def test_get_run_mode_cell_top_line(client: AsyncKernelClient):
     )
     assert content["status"] == "ok"
     assert "async_kernel_caller" in content["user_expressions"]["thread_name"]["data"]["text/plain"]
+
+
+async def test_cell_top_line_to_thread_named(client: AsyncKernelClient):
+    _, content = await utils.execute(
+        client,
+        "# thread name='My thread'\nimport threading;thread_name=threading.current_thread().name",
+        user_expressions={"thread_name": "thread_name"},
+    )
+    assert content["status"] == "ok"
+    assert "My thread" in content["user_expressions"]["thread_name"]["data"]["text/plain"]
 
 
 @pytest.mark.parametrize("mode", ["raises", "not raised"])


### PR DESCRIPTION
## Enhancements

- Cell magic 'python' is renamed to 'thread' and now accepts passing CallerCreateOptions as part of the cell magic line
- Top line "# thread" now also accepts the same options