### PR TITLE
Move kernel_info, help_links and debugger from the shell to the kernel or interface.

### DIFF
--- a/src/async_kernel/asyncshell.py
+++ b/src/async_kernel/asyncshell.py
@@ -29,7 +29,7 @@ from typing_extensions import override
 import async_kernel
 from async_kernel import utils
 from async_kernel.caller import Caller
-from async_kernel.common import Fixed, KernelInterrupt, import_item
+from async_kernel.common import Fixed, KernelInterrupt
 from async_kernel.compiler import XCachingCompiler
 from async_kernel.event_loop.run import get_runtime_matplotlib_guis
 from async_kernel.pending import Pending, PendingManager
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from anyio.abc import ByteReceiveStream
 
     from async_kernel import Kernel
-    from async_kernel.debugger import Debugger
 
 
 __all__ = ["AsyncInteractiveShell"]
@@ -208,9 +207,6 @@ class AsyncInteractiveShell(InteractiveShell):
     pending_manager = Fixed(ShellPendingManager)
     subshell_id = Fixed(lambda _: None)
 
-    debugger: Fixed[Self, Debugger | None] | None = None  # pyright: ignore[reportIncompatibleMethodOverride]
-    "Handles [debug requests](https://jupyter-client.readthedocs.io/en/stable/messaging.html#debug-request)."
-
     user_ns_hidden: Fixed[Self, dict] = Fixed(lambda c: c["owner"]._get_default_ns())
     user_global_ns: Fixed[Self, dict] = Fixed(lambda c: c["owner"]._user_ns)  # pyright: ignore[reportIncompatibleMethodOverride]
 
@@ -228,8 +224,6 @@ class AsyncInteractiveShell(InteractiveShell):
     loop_runner_map = None
     loop_runner = None
     autoindent = False
-    help_links = traitlets.Tuple()
-    ""
 
     @override
     def __repr__(self) -> str:
@@ -362,29 +356,6 @@ class AsyncInteractiveShell(InteractiveShell):
     @override
     def ns_table(self) -> dict[str, dict[Any, Any] | dict[str, Any]]:
         return {"user_global": self.user_global_ns, "user_local": self.user_ns, "builtin": builtins.__dict__}
-
-    @property
-    def kernel_info(self) -> dict[str, Any]:
-        "A dict of detail sent in reply to for a 'kernel_info_request'."
-        return {
-            "protocol_version": async_kernel.kernel_protocol_version,
-            "implementation": "async_kernel",
-            "implementation_version": async_kernel.__version__,
-            "language_info": async_kernel.kernel_protocol_version_info,
-            "banner": self.banner,
-            "help_links": self.help_links,
-            "debugger": bool(self.debugger),
-            "kernel_name": self.kernel.kernel_name,
-            "supported_features": self.supported_features,
-        }
-
-    @property
-    def supported_features(self) -> list[str]:
-        "Supported features included in the reply to a [async_kernel.kernel.Kernel.kernel_info_request][]."
-        features = ["kernel subshells"]
-        if self.debugger:
-            features.append("debugger")
-        return features
 
     async def run_line_magic_async(self, magic_name: str, line: str, _stack_depth=1) -> Any:
         "Call and awaits [run_line_magic][IPython.core.interactiveshell.InteractiveShell.run_line_magic]."
@@ -779,39 +750,6 @@ class AsyncInteractiveSubshell(AsyncInteractiveShell):
 
 class IPythonAsyncInteractiveShell(AsyncInteractiveShell):
     "The default AsyncInteractiveShell"
-
-    debugger = Fixed(
-        lambda _: (
-            import_item("async_kernel.debugger.Debugger")()
-            if (not utils.LAUNCHED_BY_DEBUGPY) & (sys.platform != "emscripten")
-            else None
-        )
-    )
-
-    @traitlets.default("help_links")
-    def _default_help_links(self) -> tuple[dict[str, str], ...]:
-        return (
-            {
-                "text": "Async Kernel Reference ",
-                "url": "https://fleming79.github.io/async-kernel/",
-            },
-            {
-                "text": "IPython Reference",
-                "url": "https://ipython.readthedocs.io/en/stable/",
-            },
-            {
-                "text": "IPython magic Reference",
-                "url": "https://ipython.readthedocs.io/en/stable/interactive/magics.html",
-            },
-            {
-                "text": "Matplotlib ipympl Reference",
-                "url": "https://matplotlib.org/ipympl/",
-            },
-            {
-                "text": "Matplotlib Reference",
-                "url": "https://matplotlib.org/contents.html",
-            },
-        )
 
 
 class IPythonInteractiveSubshell(AsyncInteractiveSubshell):

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -12,7 +12,6 @@ import signal
 import sys
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from logging import Logger, LoggerAdapter
 from typing import TYPE_CHECKING, Any, Literal, Self
 from uuid import uuid4
 
@@ -24,7 +23,7 @@ import async_kernel
 from async_kernel import utils
 from async_kernel.asyncshell import ShellPendingManager
 from async_kernel.caller import Caller
-from async_kernel.common import Fixed, KernelInterrupt
+from async_kernel.common import Fixed, KernelInterrupt, import_item
 from async_kernel.iostream import OutStream
 from async_kernel.typing import (
     Backend,
@@ -110,12 +109,17 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
     _zmq_context = None
     _handler_cache: dict[tuple[str | None, MsgType, Callable], HandlerType] = {}
 
+    debugger = Fixed(
+        lambda _: (
+            import_item("async_kernel.debugger.Debugger")()
+            if (not utils.LAUNCHED_BY_DEBUGPY) & (sys.platform != "emscripten")
+            else None
+        )
+    )
+    "A debugger adapter."
+
     def load_connection_info(self, info: dict[str, Any]) -> None:
         raise NotImplementedError
-
-    @traitlets.default("log")
-    def _default_log(self) -> LoggerAdapter[Logger]:
-        return logging.LoggerAdapter(logging.getLogger(self.__class__.__name__))
 
     @traitlets.default("handle_in_thread")
     def _default_handle_in_thread(self) -> dict[MsgType, str]:
@@ -130,6 +134,7 @@ class BaseKernelInterface(traitlets.HasTraits, anyio.AsyncContextManagerMixin):
             msg = "The kernel already has an interface!"
             raise RuntimeError(msg)
         self.kernel.interface = self
+        self.log = self.kernel.log
         super().__init__()
         if kernel_settings:
             self.kernel.load_settings(kernel_settings)

--- a/src/async_kernel/interface/zmq.py
+++ b/src/async_kernel/interface/zmq.py
@@ -508,6 +508,6 @@ class ZMQKernelInterface(BaseKernelInterface):
         """
         Perform a keyboard interrupt.
         """
-        if not getattr(self.kernel.shell.debugger, "stopped_threads", None):
+        if not getattr(self.debugger, "stopped_threads", None):
             self._interrupt_now()
         super().interrupt()

--- a/src/async_kernel/kernel.py
+++ b/src/async_kernel/kernel.py
@@ -18,6 +18,7 @@ from jupyter_core.paths import jupyter_runtime_dir
 from traitlets import traitlets
 from typing_extensions import override
 
+import async_kernel
 from async_kernel import Caller, utils
 from async_kernel.asyncshell import (
     AsyncInteractiveShell,
@@ -125,6 +126,11 @@ class Kernel(traitlets.HasTraits):
     event_stopped = Fixed(Event)
     "An event that occurs when the kernel is stopped."
 
+    help_links = traitlets.Tuple()
+    ""
+    kernel_info: traitlets.Dict[str, Any] = traitlets.Dict()
+    ""
+
     def __new__(cls, settings: dict | None = None, /) -> Self:  # noqa: ARG004
         #  There is only one instance (including subclasses).
         if not (instance := Kernel._instance):
@@ -176,6 +182,48 @@ class Kernel(traitlets.HasTraits):
     def _validate_connection_file(self, proposal) -> Path:
         return pathlib.Path(proposal.value).expanduser()
 
+    @traitlets.default("help_links")
+    def _default_help_links(self) -> tuple[dict[str, str], ...]:
+        return (
+            {
+                "text": "Async Kernel Reference ",
+                "url": "https://fleming79.github.io/async-kernel/",
+            },
+            {
+                "text": "IPython Reference",
+                "url": "https://ipython.readthedocs.io/en/stable/",
+            },
+            {
+                "text": "IPython magic Reference",
+                "url": "https://ipython.readthedocs.io/en/stable/interactive/magics.html",
+            },
+            {
+                "text": "Matplotlib ipympl Reference",
+                "url": "https://matplotlib.org/ipympl/",
+            },
+            {
+                "text": "Matplotlib Reference",
+                "url": "https://matplotlib.org/contents.html",
+            },
+        )
+
+    @traitlets.default("kernel_info")
+    def _default_kernel_info(self) -> dict[str, Any]:
+        features = ["kernel subshells"]
+        if self.interface.debugger:
+            features.append("debugger")
+        return {
+            "protocol_version": async_kernel.kernel_protocol_version,
+            "implementation": "async_kernel",
+            "implementation_version": async_kernel.__version__,
+            "language_info": async_kernel.kernel_protocol_version_info,
+            "banner": self.main_shell.banner,
+            "help_links": self.help_links,
+            "debugger": bool(self.interface.debugger),
+            "kernel_name": self.kernel_name,
+            "supported_features": features,
+        }
+
     @property
     def settings(self) -> dict[str, Any]:
         "Settings that have been set to customise the behaviour of the kernel."
@@ -195,11 +243,6 @@ class Kernel(traitlets.HasTraits):
     def caller(self) -> Caller:
         "The caller for the shell channel."
         return self.interface.callers[Channel.shell]
-
-    @property
-    def kernel_info(self) -> dict[str, Any]:
-        "A dict of detail sent in reply to for a 'kernel_info_request'."
-        return self.main_shell.kernel_info
 
     def load_settings(self, settings: dict[str, Any]) -> None:
         """
@@ -305,32 +348,32 @@ class Kernel(traitlets.HasTraits):
         self.comm_manager.comm_close(stream=None, ident=None, msg=job["msg"])  # pyright: ignore[reportArgumentType]
 
     async def interrupt_request(self, job: Job[Content], /) -> Content:
-        """Handle an [interrupt request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-interrupt) (control only)."""
+        """Handle an [interrupt request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-interrupt)."""
         self.interface.interrupt()
         return {}
 
     async def shutdown_request(self, job: Job[Content], /) -> Content:
-        """Handle a [shutdown request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-shutdown) (control only)."""
+        """Handle a [shutdown request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-shutdown)."""
         self._restart = job["msg"]["content"].get("restart", False)
         self.interface.stop()
         return {"restart": self._restart}
 
     async def debug_request(self, job: Job[Content], /) -> Content:
-        """Handle a [debug request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#debug-request) (control only)."""
-        return await self.shell.debugger.process_request(job["msg"]["content"])  # pyright: ignore[reportOptionalMemberAccess]
+        """Handle a [debug request](https://jupyter-client.readthedocs.io/en/stable/messaging.html#debug-request)."""
+        return await self.interface.debugger.process_request(job["msg"]["content"])  # pyright: ignore[reportOptionalMemberAccess]
 
     async def create_subshell_request(self: Kernel, job: Job[Content], /) -> Content:
-        """Handle a [create subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#create-subshell) (control only)."""
+        """Handle a [create subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#create-subshell)."""
 
         return {"subshell_id": self.subshell_manager.create_subshell(protected=False).subshell_id}
 
     async def delete_subshell_request(self, job: Job[Content], /) -> Content:
-        """Handle a [delete subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#delete-subshell) (control only)."""
+        """Handle a [delete subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#delete-subshell)."""
         self.subshell_manager.delete_subshell(job["msg"]["content"]["subshell_id"])
         return {}
 
     async def list_subshell_request(self, job: Job[Content], /) -> Content:
-        """Handle a [list subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#list-subshells) (control only)."""
+        """Handle a [list subshell request](https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html#list-subshells)."""
         return {"subshell_id": list(self.subshell_manager.list_subshells())}
 
     def get_connection_info(self) -> dict[str, Any]:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -368,7 +368,7 @@ async def test_debug_static(client: AsyncKernelClient, command: str, mocker):
 
 
 async def test_debug_raises_no_socket(kernel: Kernel):
-    debugger = kernel.shell.debugger
+    debugger = kernel.interface.debugger
     assert debugger
     with pytest.raises(RuntimeError):
         await debugger.debugpy_client.send_request({})


### PR DESCRIPTION
This is a more natural fit for where the attributes should exist.