### PR TITLE
Interface startup refactoring

### DIFF
--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, Self, final
 from uuid import uuid4
 
 import anyio
-from aiologic import Event
 from aiologic.lowlevel import AsyncLibraryNotFoundError, current_async_library
 from traitlets import traitlets
 from traitlets.config import Config, Configurable
@@ -177,8 +176,8 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
     callers: Fixed[Self, dict[Literal[Channel.shell, Channel.control], Caller]] = Fixed(dict)
     "The caller associated with the kernel once it has started."
 
-    event_started = Fixed(Event)
-    "An event that occurs when the interface is started."
+    started = Fixed(Pending)
+    "A Pending that is set when the interface has started."
 
     stopping = Fixed(Pending)
     """
@@ -321,14 +320,26 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
             host=self.host,
             host_options=self.host_options,
         )
-        async_kernel.event_loop.run(self.run, (), settings)
-        super().start()
+        try:
+            async_kernel.event_loop.run(self.run, (), settings)
+        finally:
+            if BaseInterface._instance is self:
+                BaseInterface._instance = None
 
     @asynccontextmanager
     async def __asynccontextmanager__(self, *, set_started=True) -> AsyncGenerator[Self]:
-        if BaseInterface._instance is not self or self.event_started:
+        def cache_iopub_send(*args, **kwargs) -> None:
+            # Cache iopub messages, send when started or discard if stopped early.
+            self.started.add_done_callback(lambda _: not self.stopping.done() and send(*args, **kwargs))
+
+        if self.stopping.done() or self.started.done():
             msg = "Stopped early"
             raise RuntimeError(msg)
+
+        send = self.iopub_send
+        self.iopub_send = cache_iopub_send
+        self.started.add_done_callback(lambda _: delattr(self, "iopub_send"))
+
         caller = Caller(
             "manual",
             name="Shell",
@@ -356,7 +367,7 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
 
     def _started(self):
         self.log.info("Interface started: %s", self.summary)
-        self.event_started.set()
+        self.started.set_result(None)
 
     async def run(self, *, stopped: Callable[[], Any] | None = None) -> None:
         """
@@ -384,8 +395,8 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
             del self._scope
             self.log.info("Stopping kernel")
             self.callers[Channel.shell].call_later(0.5, scope.cancel, "Stopping kernel")
-        if not self.event_started:
-            self.event_started.set()
+        if not self.started.done():
+            self.started.cancel("Stopped early")
             if BaseInterface._instance is self:
                 BaseInterface._instance = None
 

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -314,6 +314,10 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
             - If there is an `asyncio` or `trio` event loop already running in the desired thread;
                 start asynchronously instead (`async with interface: ...`).
         """
+        if BaseInterface._instance is not self:
+            msg = "This interface is not the global instance!"
+            raise RuntimeError(msg)
+
         settings = RunSettings(
             backend=self.backend,
             backend_options=self.backend_options,
@@ -328,7 +332,7 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
 
     @asynccontextmanager
     async def __asynccontextmanager__(self, *, set_started=True) -> AsyncGenerator[Self]:
-        def cache_iopub_send(*args, **kwargs) -> None:
+        def cache_iopub_send(*args, **kwargs) -> None:  # pragma: no cover
             # Cache iopub messages, send when started or discard if stopped early.
             self.started.add_done_callback(lambda _: not self.stopping.done() and send(*args, **kwargs))
 

--- a/src/async_kernel/interface/callable.py
+++ b/src/async_kernel/interface/callable.py
@@ -88,7 +88,7 @@ class CallableInterface(BaseInterface[T_shell_co], Generic[T_shell_co]):
         """
         self._send = send
         self._task = asyncio.create_task(coro=self.run(stopped=stopped))
-        await self.event_started
+        await self.started
         return Handlers(handle_msg=self._handle_msg, stop=self.stop)
 
     def _send_to_frontend(

--- a/src/async_kernel/interface/zmq.py
+++ b/src/async_kernel/interface/zmq.py
@@ -112,14 +112,15 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
     @override
     @asynccontextmanager
     async def __asynccontextmanager__(self, *, set_started=True) -> AsyncGenerator[Self]:
+
         if os.path.exists(self.connection_file):  # noqa: PTH110
             self.load_connection_file()
         self.write_connection_file()
         try:
-            self._start_hb_iopub_shell_control_threads()
-            with self._bind_socket(Channel.stdin):
-                assert len(self._sockets) == len(Channel)
-                async with super().__asynccontextmanager__(set_started=False):
+            async with super().__asynccontextmanager__(set_started=False):
+                self._start_hb_iopub_shell_control_threads()
+                with self._bind_socket(Channel.stdin):
+                    assert len(self._sockets) == len(Channel)
                     if set_started:
                         self._started()
                     yield self
@@ -132,7 +133,7 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
             utils.mark_thread_pydev_do_not_trace()
             with self._bind_socket(Channel.heartbeat) as socket:
                 ready.set()
-                self.event_started.wait()
+                self.started.wait_sync()
                 try:
                     zmq.proxy(socket, socket)
                 except zmq.ContextTerminated:
@@ -191,6 +192,7 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
         socket.subscribe(b"\x01")
         with socket:
             ready.wait()
+            self.started.wait_sync()
             while True:
                 try:
                     if frames := socket.recv_multipart():
@@ -304,7 +306,7 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
         if not utils.LAUNCHED_BY_DEBUGPY:
             utils.mark_thread_pydev_do_not_trace()
 
-        session, log, message_handler, iopub_send = self.session, self.log, self.kernel.message_handler, self.iopub_send
+        session, log, message_handler = self.session, self.log, self.kernel.message_handler
         lock = BinarySemaphore()
 
         async def send_reply(job: Job, content: dict, /) -> None:
@@ -324,13 +326,14 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
 
         with self._bind_socket(channel) as socket:
             ready.set()
-            self.event_started.wait()
+            self.started.wait_sync()
+
             while True:
                 try:
                     ident, msg = session.recv(socket, mode=zmq.BLOCKY, copy=False)
                     msg["channel"] = channel  # pyright: ignore[reportOptionalSubscript]
                     job = Job(received_time=time.monotonic(), msg=msg, ident=ident)  # pyright: ignore[reportArgumentType]
-                    message_handler(job, send_reply, iopub_send)
+                    message_handler(job, send_reply, self.iopub_send)
                 except zmq.ContextTerminated:
                     break
                 except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ async def kernel(anyio_backend, transport: str, request, tmp_path_factory):
                 interface.backend_options = {}
             thread = threading.Thread(target=interface.start, name="ShellThread")
             thread.start()
-            interface.event_started.wait()
+            await interface.started
             assert os.environ["MPLBACKEND"] == utils.MATPLOTLIB_INLINE_BACKEND
             await interface.kernel.caller.call_soon(check_anyio_backend, anyio_backend)
             try:

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -16,6 +16,8 @@ from async_kernel.shell import BaseShell
 if TYPE_CHECKING:
     from async_kernel.typing import Backend
 
+# pyright: reportPrivateUsage=false
+
 
 class TestBaseInterface:
     async def test_instance_does_not_exist(self, anyio_backend: Backend):
@@ -85,11 +87,21 @@ class TestBaseInterface:
     async def test_stop_early(self, anyio_backend: Backend):
         app = BaseInterface(shell_class=BaseShell)
         app.stop()
+        with pytest.raises(RuntimeError, match="This interface is not the global instance!"):
+            app.start()
         with pytest.raises(RuntimeError, match="An instance does not exist"):
             BaseInterface.instance()
         with pytest.raises(RuntimeError, match="Stopped early"):
             async with app:
                 pass
+
+    def test_start_bad_settings(self):
+
+        app = BaseInterface(shell_class=BaseShell, backend_options={"loop_factory": "not a factory"})
+        assert BaseInterface._instance is app
+        with pytest.raises(TypeError, match="object is not callable"):
+            app.start()
+        assert BaseInterface._instance is None
 
 
 class TestHasInterface:

--- a/tests/test_callable_interface.py
+++ b/tests/test_callable_interface.py
@@ -46,7 +46,7 @@ async def interface(anyio_backend):
 
 class TestCallableInterface:
     async def test_start(self, interface: CallableInterface):
-        assert interface.event_started
+        assert interface.started
 
     async def test_msg(self, interface: CallableInterface, mocker):
         sender = mocker.patch.object(interface, "_send")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Literal, cast
 import anyio
 import pytest
 from aiologic import Event
-from typing_extensions import override
 
 import async_kernel
-from async_kernel import Kernel
+from async_kernel import Kernel, Pending
 from async_kernel.command import command_line, to_flags_and_settings
 from async_kernel.interface.ip_app import IPApp
 from async_kernel.interface.zmq import ZMQInterface
@@ -193,15 +192,13 @@ def test_list(monkeypatch, config: str, capsys):
 
 
 def test_command_launch_interface(monkeypatch, fake_kernel_dir: pathlib.Path):
-    class EventSet(Event):
-        @override
-        def set(self):
-            super().set()
-            kernel: Kernel[BaseInterface[IPShell], IPShell] = async_kernel.utils.get_kernel()  # pyright: ignore[reportAssignmentType]
-            assert kernel.parent.backend_options == {"use_uv": False}
-            assert kernel.shell.timeout == 0.123
-            assert kernel.shell.automagic is False
-            kernel.caller.call_direct(kernel.parent.stop)
+
+    def on_started(pen):
+        kernel: Kernel[BaseInterface[IPShell], IPShell] = async_kernel.utils.get_kernel()  # pyright: ignore[reportAssignmentType]
+        assert kernel.parent.backend_options == {"use_uv": False}
+        assert kernel.shell.timeout == 0.123
+        assert kernel.shell.automagic is False
+        kernel.caller.call_direct(kernel.parent.stop)
 
     cmd = [
         "prog",
@@ -212,8 +209,9 @@ def test_command_launch_interface(monkeypatch, fake_kernel_dir: pathlib.Path):
         "--BaseShell.timeout=0.123",
         "--no-automagic",
     ]
-    event_started = EventSet()
-    monkeypatch.setattr(ZMQInterface, "event_started", event_started)
+    pen = Pending()
+    pen.add_done_callback(on_started)
+    monkeypatch.setattr(ZMQInterface, "started", pen)
     monkeypatch.setattr(sys, "argv", cmd)
     with pytest.raises(SystemExit) as e:
         command_line()
@@ -241,17 +239,14 @@ def test_command_launch_ZMQInterface_with_host(mocker, monkeypatch, backend, hos
     monkeypatch.setattr(sys, "argv", cmd)
     kernel = cast("Kernel", None)  # pyright: ignore[reportInvalidCast]
 
-    class EventSet(Event):
-        @override
-        def set(self):
-            nonlocal kernel
-            kernel = async_kernel.utils.get_kernel()
-            super().set()
-            kernel.caller.call_direct(kernel.parent.stop)
+    def on_started(self):
+        nonlocal kernel
+        kernel = async_kernel.utils.get_kernel()
+        kernel.caller.call_direct(kernel.parent.stop)
 
-    event_started = EventSet()
-
-    monkeypatch.setattr(ZMQInterface, "event_started", event_started)
+    pen = Pending()
+    pen.add_done_callback(on_started)
+    monkeypatch.setattr(ZMQInterface, "started", pen)
 
     with pytest.raises(SystemExit) as e:
         command_line()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -15,6 +15,7 @@ from aiologic import Event
 import async_kernel
 from async_kernel import Kernel, Pending
 from async_kernel.command import command_line, to_flags_and_settings
+from async_kernel.interface.base import BaseInterface
 from async_kernel.interface.ip_app import IPApp
 from async_kernel.interface.zmq import ZMQInterface
 from async_kernel.kernelspec import make_argv
@@ -26,9 +27,10 @@ if TYPE_CHECKING:
 
     from jupyter_client.asynchronous.client import AsyncKernelClient
 
-    from async_kernel.interface.base import BaseInterface
     from async_kernel.kernel import Kernel
     from async_kernel.shell import IPShell
+
+# pyright: reportPrivateUsage=false
 
 
 @pytest.fixture(scope="module", params=["tcp", "ipc"] if sys.platform == "linux" else ["tcp"])
@@ -77,6 +79,7 @@ def test_prints_help_when_no_args(monkeypatch, capsys):
     assert e.value.code == 0
     out = capsys.readouterr().out
     assert "usage:" in out
+    assert BaseInterface._instance is None
 
 
 def test_prints_version_info(monkeypatch, capsys):
@@ -86,6 +89,7 @@ def test_prints_version_info(monkeypatch, capsys):
     assert e.value.code == 0
     out = capsys.readouterr().out
     assert f"async-kernel {async_kernel.__version__}" in out
+    assert BaseInterface._instance is None
 
 
 def test_prints_help_all(monkeypatch, capsys):
@@ -95,6 +99,7 @@ def test_prints_help_all(monkeypatch, capsys):
     assert e.value.code == 0
     out = capsys.readouterr().out
     assert "aliases" in out
+    assert BaseInterface._instance is None
 
 
 def test_show_config(monkeypatch, capsys):
@@ -105,6 +110,7 @@ def test_show_config(monkeypatch, capsys):
         assert e.value.code == 0
         out = capsys.readouterr().out
         assert "IPApp" in out
+        assert BaseInterface._instance is None
 
 
 def test_install_kernel_start_zmq_interface(monkeypatch, fake_kernel_dir: pathlib.Path, capsys):
@@ -122,6 +128,7 @@ def test_install_kernel_start_zmq_interface(monkeypatch, fake_kernel_dir: pathli
     )
     with pytest.raises(SystemExit) as e:
         command_line()
+    assert BaseInterface._instance is None
     assert e.value.code == 0
     kernel_dir = fake_kernel_dir.joinpath("async-trio")
     assert (kernel_dir).exists()

--- a/tests/test_enter_kernel.py
+++ b/tests/test_enter_kernel.py
@@ -10,7 +10,7 @@ async def test_start_kernel_in_context(anyio_backend):
     async with ZMQInterface() as interface:
         assert isinstance(interface, ZMQInterface)
         connection_file = interface.connection_file
-        assert interface.event_started
+        assert interface.started
         assert interface.backend == anyio_backend
         # Test prohibit nested async context.
         with pytest.raises(RuntimeError, match="has already been entered"):
@@ -20,5 +20,5 @@ async def test_start_kernel_in_context(anyio_backend):
     interface2.connection_file = connection_file
     async with interface2:
         # Test we start a new kernel.
-        assert interface2.event_started
+        assert interface2.started
         assert interface2 is not interface.kernel


### PR DESCRIPTION
- replace event_started Event with 'started' pending.
- change order of ZMQ super call (start caller before sockets)
- delay all iopub_send messages until started is callled.