### PR TITLE
Simplify zmq interface and remove zmq context from Caller.

### DIFF
--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from types import CoroutineType
 
     import trio  # noqa: TC004
-    import zmq
     from aiologic.lowlevel import AsyncEvent
 
     from async_kernel.typing import P
@@ -196,7 +195,6 @@ class Caller(anyio.AsyncContextManagerMixin):
         CallerState.stopping: "🏁 stopping",
         CallerState.stopped: "🏁 stopped",
     }
-    _zmq_context: zmq.Context[Any] | None = None
 
     _parent_ref: weakref.ref[Self] | None = None
 
@@ -220,10 +218,6 @@ class Caller(anyio.AsyncContextManagerMixin):
     _pending_var: contextvars.ContextVar[Pending | None] = contextvars.ContextVar("_pending_var", default=None)
 
     log: logging.Logger | logging.LoggerAdapter
-    ""
-    iopub_sockets: ClassVar[dict[int, zmq.Socket]] = {}
-    ""
-    iopub_url: ClassVar = "inproc://iopub"
     ""
 
     @property
@@ -260,11 +254,6 @@ class Caller(anyio.AsyncContextManagerMixin):
     def protected(self) -> bool:
         "Returns `True` if the caller is protected from stopping."
         return self._protected
-
-    @property
-    def zmq_context(self) -> zmq.Context | None:
-        "A zmq socket, which if present indicates that an iopub socket is loaded."
-        return self._zmq_context
 
     @property
     def running(self) -> bool:
@@ -335,7 +324,6 @@ class Caller(anyio.AsyncContextManagerMixin):
                 - backend: The async backend to use.
                 - backend_options: Options for the backend.
                 - protected: Whether the Caller is protected.
-                - zmq_context: ZeroMQ context.
                 - log: Logger instance.
 
         Returns:
@@ -378,7 +366,6 @@ class Caller(anyio.AsyncContextManagerMixin):
             inst._backend_options = kwargs.get("backend_options")
             inst._host_options = kwargs.get("host_options")
             inst._protected = kwargs.get("protected", False)
-            inst._zmq_context = kwargs.get("zmq_context")
             inst.log = kwargs.get("log") or logging.LoggerAdapter(logging.getLogger())
             if (sys.platform == "emscripten") and (caller_id is None):
                 caller_id = id(inst)
@@ -501,12 +488,7 @@ class Caller(anyio.AsyncContextManagerMixin):
         if self._state is CallerState.stopped:
             msg = f"Stopped: {self}"
             raise RuntimeError(msg)
-        socket = None
         try:
-            if self._zmq_context:
-                socket = self._zmq_context.socket(1)  # zmq.SocketType.PUB
-                socket.connect(self.iopub_url)
-                self.iopub_sockets[self._caller_id] = socket
             async with task_factory() as create_task:
                 try:
                     create_task(contextvars.Context(), self._scheduler, self._queue)
@@ -527,9 +509,6 @@ class Caller(anyio.AsyncContextManagerMixin):
                             await caller.stopped
                 except KeyError:
                     pass
-            if socket:
-                self.iopub_sockets.pop(self._caller_id, None)
-                socket.close(linger=0)
             self._stop_finalize()
 
     async def _scheduler(self, queue: SingleAsyncQueue) -> None:
@@ -682,8 +661,8 @@ class Caller(anyio.AsyncContextManagerMixin):
             RuntimeError: If a caller with the specified name exists but the backend does not match.
 
         Notes:
-            - The returned caller is added to `children` and stopped with the caller.
-            - If 'backend' or 'zmq_context' are not specified they are copied from the caller.
+            - The returned caller is added to `children` and stopped with this caller.
+            - If 'backend' is not specified it is taken from this caller.
         """
         if self._state in [CallerState.stopping, CallerState.stopped]:
             msg = f"Caller is stopping or stopped {self}"
@@ -702,8 +681,6 @@ class Caller(anyio.AsyncContextManagerMixin):
             if "backend" not in kwargs:
                 kwargs["backend"] = self._backend
                 kwargs["backend_options"] = self.backend_options
-            if "zmq_context" not in kwargs and self._zmq_context:
-                kwargs["zmq_context"] = self._zmq_context
             caller = self.__class__("NewThread", **kwargs)
             self._children.add(caller)
             caller._parent_ref = weakref.ref(self)

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -184,8 +184,6 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
     """
 
     _instance: Self | None = None
-    _zmq_context = None
-    last_interrupt_frame = None
 
     @traitlets.default("backend")
     def _default_backend(self) -> Backend:
@@ -344,14 +342,7 @@ class BaseInterface(Application, anyio.AsyncContextManagerMixin, Generic[T_shell
         self.iopub_send = cache_iopub_send
         self.started.add_done_callback(lambda _: delattr(self, "iopub_send"))
 
-        caller = Caller(
-            "manual",
-            name="Shell",
-            protected=True,
-            log=self.log,
-            zmq_context=self._zmq_context,
-            host=self.host,
-        )
+        caller = Caller("manual", name="Shell", protected=True, log=self.log, host=self.host)
         self.callers[Channel.shell] = caller
         self.callers[Channel.control] = caller.get(name="Control", log=self.log, protected=True)
         self.backend = Backend(current_async_library())

--- a/src/async_kernel/interface/poll_zmq.py
+++ b/src/async_kernel/interface/poll_zmq.py
@@ -80,7 +80,9 @@ class PollZMQ:
                         if e.errno == zmq.Errno.ENOTSOCK:
                             # This exception occurs when the interpreter is shutting down.
                             return
-                    except Exception:
+                    except SystemExit:
+                        return
+                    except BaseException:
                         continue
             finally:
                 callbacks.clear()
@@ -118,11 +120,7 @@ class PollZMQ:
                 pass
 
     def stop(self) -> None:
-        """
-        Stop the poll thread.
-
-        Once stopped, the poller cannot be restarted.
-        """
+        """Stop the poll thread."""
         if not self.stopped:
             self._handlers.clear()
             if self._thread:

--- a/src/async_kernel/interface/zmq.py
+++ b/src/async_kernel/interface/zmq.py
@@ -5,30 +5,28 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-import threading
 import time
-from collections.abc import Callable
+from collections.abc import Generator
 from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, Generic, Literal, Never, Self
 
+import jupyter_client.session
 import zmq
 from aiologic import BinarySemaphore
-from aiologic.lowlevel import AsyncEvent, create_async_event, enable_signal_safety
+from aiologic.lowlevel import enable_signal_safety
 from jupyter_client.connect import ConnectionFileMixin
-from jupyter_client.session import Session
 from traitlets import traitlets
 from typing_extensions import override
 from zmq import Flag, PollEvent, Socket, SocketOption
 
 from async_kernel import utils
-from async_kernel.caller import Caller
 from async_kernel.common import Fixed, KernelInterrupt, MethodNotSupported
 from async_kernel.interface.base import BaseInterface, HasInterface
 from async_kernel.interface.poll_zmq import PollZMQ
 from async_kernel.typing import Channel, Content, Job, Message, MsgHeader, NoValue, T_shell_co
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable, Generator
+    from collections.abc import AsyncGenerator, Generator
 
     from jupyter_client import KernelConnectionInfo
 
@@ -36,7 +34,7 @@ if TYPE_CHECKING:
 __all__ = ["ZMQInterface"]
 
 
-class AsyncSession(HasInterface, Session):
+class Session(HasInterface, jupyter_client.session.Session):
     check_pid = traitlets.Bool(False).tag(config=True)
 
 
@@ -59,20 +57,21 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
     }
     ""
 
-    session = traitlets.Instance(AsyncSession, ())
-    ""
+    session = traitlets.Instance(Session, ())
+    "Provides messaging utilities."
 
     transport: traitlets.CaselessStrEnum[str] = traitlets.CaselessStrEnum(
         ["tcp", "ipc"] if sys.platform == "linux" else ["tcp"], default_value="tcp"
     ).tag(config=True)
     "Transport for sockets."
 
-    _initialized = False
+    _iopub_send_lock = BinarySemaphore()
+
     _zmq_context = Fixed(zmq.Context)
-    _iopub_url = "inproc://iopub-capture"
+
     _sockets: Fixed[Self, dict[Channel, zmq.Socket]] = Fixed(dict)
 
-    poll_zmq: Fixed[Self, PollZMQ] = Fixed(PollZMQ)
+    _poll_zmq: Fixed[Self, PollZMQ] = Fixed(PollZMQ)
 
     @traitlets.validate("connection_file")
     def _validate_connection_file(self, proposal: dict) -> str:
@@ -125,82 +124,29 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
         if os.path.exists(self.connection_file):  # noqa: PTH110
             self.load_connection_file()
         self.write_connection_file()
-        with self._open_sockets() as ready:
-            async with super().__asynccontextmanager__(set_started=False):
-                await ready
-                assert len(self._sockets) == len(Channel)
-                self.started.add_done_callback(lambda _: self.poll_zmq.start())
-                if set_started:
-                    self._started()
-                yield self
-
-    @contextmanager
-    def _open_sockets(self) -> Generator[AsyncEvent, Any, None]:
-        ready = create_async_event()
         try:
             with (
                 self._heartbeat(),
-                self._message_handler(Channel.shell),
-                self._message_handler(Channel.control),
+                self._iopub(),
                 self._bind_socket(Channel.stdin),
+                self._message_handler(Channel.control),
+                self._message_handler(Channel.shell),
             ):
-                threading.Thread(target=self._pub_proxy, name="iopub proxy", args=[ready.set]).start()
-                yield ready
+                async with super().__asynccontextmanager__(set_started=False):
+                    assert len(self._sockets) == len(Channel)
+                    self.started.add_done_callback(lambda _: self._poll_zmq.start())
+                    if set_started:
+                        self._started()
+                    yield self
         finally:
-            self.poll_zmq.stop()
-            self.log.info("Destroying zmq context")
-            self._zmq_context.destroy(0)
-            self.log.info("zmq context destroyed")
-
-    @contextmanager
-    def _heartbeat(self) -> Generator[None, Any, None]:
-        # ref: https://jupyter-client.readthedocs.io/en/stable/messaging.html#heartbeat-for-kernels
-        def heartbeat(socket: zmq.Socket, flags: int) -> None:
-            msg = socket.recv_multipart()
-            socket.send_multipart(msg)
-
-        with self._bind_socket(Channel.heartbeat) as socket, self.poll_zmq.event_handler(socket, heartbeat):
-            yield
-
-    def _pub_proxy(self, ready: Callable[[], None]) -> None:
-        utils.mark_thread_pydev_do_not_trace()
-
-        def on_reg_msg(socket: Socket, flags: int) -> None:
-            if frames := socket.recv_multipart():
-                frame = next(iter(frames))
-                if frame[0] == 1:
-                    msg = self.msg("iopub_welcome", content={"subscription": frame[1:].decode()})
-                    self.iopub_send(msg, parent=None)
-
-        # We use an internal proxy to collect pub messages for distribution.
-        # Each thread needs to open its own socket to publish to the internal proxy.
-        # Ref: https://zguide.zeromq.org/docs/chapter2/#Working-with-Messages (fig 14)
-
-        frontend: zmq.Socket = self._zmq_context.socket(zmq.XSUB)
-        frontend.bind(Caller.iopub_url)
-
-        # Capture broadcast messages received on both frontend and backend
-        # welcome_message:  https://jupyter.org/enhancement-proposals/65-jupyter-xpub/jupyter-xpub.html#replace-pub-socket-with-xpub-socket
-        capture: zmq.Socket = zmq.Context(0).socket(zmq.PUB)
-        capture_: zmq.Socket = capture.context.socket(zmq.SUB)
-
-        capture.bind(self._iopub_url)
-        capture_.connect(self._iopub_url)
-        # Only subscribe to the 'pub subscribe' topic byte `1` (byte `0` is 'pub unsubscribe').
-        capture_.subscribe(b"\x01")
-
-        with (
-            self._bind_socket(Channel.iopub) as iopub_socket,
-            capture,
-            capture_,
-            self.poll_zmq.event_handler(capture_, on_reg_msg),
-            contextlib.suppress(zmq.ContextTerminated, Exception),
-        ):
-            ready()
-            zmq.proxy(frontend, iopub_socket, capture)
+            self.log.debug("Stopping PollZMQ")
+            self._poll_zmq.stop()
+            self.log.debug("Terminating zmq Context")
+            self._zmq_context.term()
+            self.log.debug("ZMQ Interface stopped")
 
     @contextlib.contextmanager
-    def _bind_socket(self, channel: Channel) -> Generator[Any | Socket[Any], Any, None]:
+    def _bind_socket(self, channel: Channel) -> Generator[Socket[Any]]:
         """
         Bind a zmq.Socket storing a reference to the socket and the port
         details and closing the socket on leaving the context.
@@ -211,16 +157,16 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
 
         match channel:
             case Channel.shell | Channel.control | Channel.heartbeat | Channel.stdin:
-                socket_type = zmq.ROUTER
+                socket: zmq.Socket = self._zmq_context.socket(zmq.ROUTER)
             case Channel.iopub:
-                socket_type = zmq.XPUB
-        socket: zmq.Socket = self._zmq_context.socket(socket_type)
-        socket.linger = 1000
+                socket = self._zmq_context.socket(zmq.XPUB)
+
         if self.curve_secretkey is not None and self.curve_publickey is not None:
             socket.curve_secretkey = self.curve_secretkey
             socket.curve_publickey = self.curve_publickey
             socket.curve_server = True
-        # bind the socket
+
+        # Bind the socket.
         addr = f"tcp://{self.ip}:{port}" if self.transport == "tcp" else f"ipc://{self.ip}-{port}"
         socket.bind(addr)
         self.log.debug("%s socket on port: %i", channel, port)
@@ -228,8 +174,71 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
         try:
             yield socket
         finally:
-            socket.close(linger=50)
+            socket.close(linger=500)
             self._sockets.pop(channel)
+            self.log.debug("%s socket closed", channel)
+
+    @contextmanager
+    def _heartbeat(self) -> Generator[None]:
+        "https://jupyter-client.readthedocs.io/en/stable/messaging.html#heartbeat-for-kernels"
+
+        def heartbeat(socket: zmq.Socket, flags: int) -> None:
+            # Thread: PollZMQ
+            msg = socket.recv()
+            socket.send(msg)
+
+        with self._bind_socket(Channel.heartbeat) as socket, self._poll_zmq.event_handler(socket, heartbeat):
+            yield
+
+    @contextmanager
+    def _iopub(self) -> Generator[None]:
+        def on_reg_msg(socket: Socket, flags: int) -> None:
+            "https://jupyter-client.readthedocs.io/en/stable/messaging.html#welcome-message"
+            # Thread: PollZMQ
+            msg = socket.recv()
+            if msg[0] == 1:
+                ident = msg[1:]
+                msg = self.msg("iopub_welcome", content={"subscription": ident.decode()})
+                self.iopub_send(msg, parent=None, ident=ident)
+
+        with self._bind_socket(Channel.iopub) as iopub_socket, self._poll_zmq.event_handler(iopub_socket, on_reg_msg):
+            yield
+
+    @contextmanager
+    def _message_handler(self, channel: Literal[Channel.control, Channel.shell]):
+        """
+        Opens a zmq socket for the channel, receives messages and calls the message handler.
+        """
+        session, log, message_handler = self.session, self.log, self.kernel.message_handler
+        lock = BinarySemaphore()
+
+        async def send_reply(job: Job, content: dict, /) -> None:
+            if "status" not in content:
+                content["status"] = "ok"
+            async with lock:
+                msg = session.send(
+                    stream=socket,
+                    msg_or_type=job["msg"]["header"]["msg_type"].replace("request", "reply"),
+                    content=content,
+                    parent=job["msg"],  # pyright: ignore[reportArgumentType]
+                    ident=job["ident"],
+                    buffers=content.pop("buffers", None),
+                )
+                if msg:
+                    log.debug("send_reply %s %s", channel, msg)
+
+        def recv_msg(socket: Socket, flags: int) -> None:
+            # Thread: PollZMQ
+            try:
+                ident, msg = session.recv(socket, mode=zmq.DONTWAIT)
+                msg["channel"] = channel  # pyright: ignore[reportOptionalSubscript]
+                job = Job(received_time=time.monotonic(), msg=msg, ident=ident)  # pyright: ignore[reportArgumentType]
+                message_handler(job, send_reply, self.iopub_send)
+            except Exception as e:
+                log.debug("Bad message on %s: %s", channel, e)
+
+        with self._bind_socket(channel) as socket, self._poll_zmq.event_handler(socket, recv_msg):
+            yield
 
     @override
     def input_request(self, prompt: str, *, password=False) -> Any:
@@ -238,7 +247,7 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
             msg = "Stdin is not allowed in this context!"
             raise RuntimeError(msg)
         socket = self._sockets[Channel.stdin]
-        # Clear messages on the stdin socket
+        # Clear messages on the stdin socket.
         while socket.get(SocketOption.EVENTS) & PollEvent.POLLIN:  # pyright: ignore[reportOperatorIssue]
             socket.recv_multipart(flags=Flag.DONTWAIT)
         # Send the input request.
@@ -272,60 +281,17 @@ class ZMQInterface(BaseInterface[T_shell_co], ConnectionFileMixin, Generic[T_she
         """
         Send a message on the zmq iopub socket.
         """
-        if socket := Caller.iopub_sockets.get(t_ident := Caller.id_current()):
-            msg = self.session.send(
-                stream=socket,
-                msg_or_type=msg_or_type,  # pyright: ignore[reportArgumentType]
-                content=content,
-                metadata=metadata,
-                parent=parent if parent is not NoValue else utils.get_parent_message(),  # pyright: ignore[reportArgumentType]
-                ident=ident,
-                buffers=buffers,  # pyright: ignore[reportArgumentType]
-            )
-            if msg:
-                self.log.debug("iopub_send: msg_type:'%s', content: %s", msg["header"]["msg_type"], msg["content"])
-        elif (caller := self.callers.get(Channel.control)) and caller.id != t_ident:
-            caller.call_direct(
-                self.iopub_send,
-                msg_or_type=msg_or_type,
-                content=content,
-                metadata=metadata,
-                parent=parent if parent is not NoValue else None,
-                ident=ident,
-                buffers=buffers,
-            )
 
-    @contextmanager
-    def _message_handler(self, channel: Literal[Channel.control, Channel.shell]):
-        """
-        Opens a zmq socket for the channel, receives messages and calls the message handler.
-        """
-        session, log, message_handler = self.session, self.log, self.kernel.message_handler
-        lock = BinarySemaphore()
-
-        async def send_reply(job: Job, content: dict, /) -> None:
-            if "status" not in content:
-                content["status"] = "ok"
-            async with lock:
-                msg = session.send(
+        with self._iopub_send_lock:
+            if socket := self._sockets.get(Channel.iopub):
+                msg = self.session.send(
                     stream=socket,
-                    msg_or_type=job["msg"]["header"]["msg_type"].replace("request", "reply"),
+                    msg_or_type=msg_or_type,  # pyright: ignore[reportArgumentType]
                     content=content,
-                    parent=job["msg"],  # pyright: ignore[reportArgumentType]
-                    ident=job["ident"],
-                    buffers=content.pop("buffers", None),
+                    metadata=metadata,
+                    parent=parent if parent is not NoValue else utils.get_parent_message(),  # pyright: ignore[reportArgumentType]
+                    ident=ident,
+                    buffers=buffers,  # pyright: ignore[reportArgumentType]
                 )
                 if msg:
-                    log.debug("***send_reply %s*** %s", channel, msg)
-
-        def recv_msg(socket: Socket, flags: int) -> None:
-            try:
-                ident, msg = session.recv(socket, mode=zmq.DONTWAIT)
-                msg["channel"] = channel  # pyright: ignore[reportOptionalSubscript]
-                job = Job(received_time=time.monotonic(), msg=msg, ident=ident)  # pyright: ignore[reportArgumentType]
-                message_handler(job, send_reply, self.iopub_send)
-            except Exception as e:
-                log.debug("Bad message on %s: %s", channel, e)
-
-        with self._bind_socket(channel) as socket, self.poll_zmq.event_handler(socket, recv_msg):
-            yield
+                    self.log.debug("iopub_send: msg_type:'%s', content: %s", msg["header"]["msg_type"], msg["content"])

--- a/src/async_kernel/typing.py
+++ b/src/async_kernel/typing.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
     import datetime
     import logging
 
-    import zmq
-
     from async_kernel.interface import BaseInterface
     from async_kernel.shell import BaseShell
     from async_kernel.shell.ipshell import IPShell
@@ -450,9 +448,6 @@ class CallerCreateOptions(RunSettings):
     "Options to pass when calling [anyio.run][]."
     protected: NotRequired[bool]
     "The caller should be protected against accidental closure (default=`False`)."
-
-    zmq_context: NotRequired[zmq.Context[Any] | None]
-    "A zmq Context to use."
 
     no_debug: NotRequired[bool]
     "Disable debugpy in the thread if a new thread is created."

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -142,9 +142,6 @@ class TestCaller:
         caller.call_direct(lambda: pen)
         assert await caller.call_soon(lambda: pen) is pen
 
-    async def test_zmq_context(self, caller: Caller):
-        assert caller.zmq_context is None
-
     async def test_repr_caller_result(self, caller):
         async def test_func(a, b, c):
             pass

--- a/tests/test_zmq_interface.py
+++ b/tests/test_zmq_interface.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from async_kernel import Kernel
     from async_kernel.shell import IPShell
 
-
 # pyright: reportPrivateUsage=false
 
 

--- a/tests/test_zmq_interface_ip.py
+++ b/tests/test_zmq_interface_ip.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+import zmq
 
 from async_kernel.interface import BaseInterface
 from async_kernel.interface.ip_app import IPApp
@@ -29,3 +30,22 @@ async def test_user_ns(anyio_backend: Backend):
         assert interface.user_ns is interface.shell.user_ns
         with pytest.raises(AttributeError):
             interface.user_ns = {}  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@pytest.mark.parametrize("topic", ["", "kernel"])
+async def test_iopub_welcome(topic: str, anyio_backend: Backend):
+    """Test iopub welcome message. https://jupyter-client.readthedocs.io/en/stable/messaging.html#welcome-message"""
+    async with IPApp() as interface:
+        ip, port, transport = interface.ip, interface.iopub_port, interface.transport
+        addr = f"tcp://{ip}:{port}" if transport == "tcp" else f"ipc://{ip}-{port}"
+        sock = interface._zmq_context.socket(zmq.SUB)
+        try:
+            sock.connect(addr)
+            sock.subscribe(topic)
+            ident, msg = interface.session.recv(sock, zmq.BLOCKY)
+            assert ident == [topic.encode()]
+            assert msg
+            assert msg["msg_type"] == "iopub_welcome"
+            assert msg["content"]["subscription"] == topic
+        finally:
+            sock.close(0)


### PR DESCRIPTION
### Enhancements
- ZMQ interface startup all contexts for more deterministic startup and shutdown
- IOPub socket changes
  - No internal proxy
  - A thread lock is used for sending iopub messages
  - Fixed iopub welcome message for subscribers with a topic
- Caller - dropped zmq context and iopub socket