### PR TITLE
Caller async context management changes

### DIFF
--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -502,29 +502,6 @@ class Caller:
                 pass
         return True
 
-    def stop(self, *, force: bool = False) -> None:
-        """Stop the caller cancelling all incomplete tasks.
-
-        Args:
-            force: If the caller is protected the call is a no-op unless force=True.
-
-        Returns:
-            Event: If stopping is initiated or complete.
-            None: If stop is ignored when the caller is protected.
-        """
-        if self._protected and not force:
-            self.log.warning("Non-force stop ignored for  %s", self)
-            return
-        with self._inst_lock:
-            state = self._state
-            if (
-                self._set_state(CallerState.stopping)
-                and state.value < CallerState.running.value
-                and not self.stopped.done()
-            ):
-                self._set_state(CallerState.stopped)
-
-
     async def _run_scheduler(self):
         """Run the scheduler until stopped."""
         try:
@@ -672,6 +649,28 @@ class Caller:
             running_only: Restrict the list to callers that are active (running in an async context).
         """
         return [caller for caller in Caller._instances.values() if caller.running or not running_only]
+
+    def stop(self, *, force: bool = False) -> None:
+        """Stop the caller cancelling all incomplete tasks.
+
+        Args:
+            force: If the caller is protected the call is a no-op unless force=True.
+
+        Returns:
+            Event: If stopping is initiated or complete.
+            None: If stop is ignored when the caller is protected.
+        """
+        if self._protected and not force:
+            self.log.warning("Non-force stop ignored for  %s", self)
+            return
+        with self._inst_lock:
+            state = self._state
+            if (
+                self._set_state(CallerState.stopping)
+                and state.value < CallerState.running.value
+                and not self.stopped.done()
+            ):
+                self._set_state(CallerState.stopped)
 
     def get(self, **kwargs: Unpack[CallerCreateOptions]) -> Self:
         """Retrieves an existing child caller by `name` and `backend`, or creates a new one if not found.

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -171,7 +171,7 @@ class Caller:
     CALLER_MAIN_THREAD_ID: int = int(threading.main_thread().ident)  # pyright: ignore[reportArgumentType]
 
     _caller_token = contextvars.ContextVar("caller_tokens", default=CALLER_MAIN_THREAD_ID)
-    _instances: ClassVar[dict[int, Self]] = {}
+    _instances: ClassVar[weakref.WeakValueDictionary[int, Self]] = weakref.WeakValueDictionary()
     _lock: ClassVar = BinarySemaphore()
 
     _thread: threading.Thread
@@ -413,7 +413,7 @@ class Caller:
             if not self._set_state(CallerState.start_sync):
                 return
 
-        async def run_caller_in_context() -> None:
+        async def run_scheduler() -> None:
             with self._inst_lock:
                 if not self._set_state(CallerState.starting):
                     return
@@ -422,16 +422,27 @@ class Caller:
             if no_debug:
                 utils.mark_thread_pydev_do_not_trace()
             try:
-                await self._run_scheduler()
+                with self._inst_lock:
+                    if not self._set_state(CallerState.running):
+                        return
+                async with task_factory() as create_task:
+                    create_task(contextvars.Context(), self._scheduler, self._queue)
+                    await self._stopping
+                    await self._guest_done_event
+                    await self._children_countdown
             except Exception as e:
                 self.log.exception("Caller did not exit context nicely!", exc_info=e)
+            finally:
+                with self._inst_lock:
+                    self._set_state(CallerState.stopping)
+                    self._set_state(CallerState.stopped)
 
         if caller_id and thread:
             assert thread is threading.current_thread()
             self._thread, self._caller_id = thread, caller_id
 
             if self.backend == Backend.asyncio:
-                self._tasks.add(asyncio.create_task(run_caller_in_context()))
+                self._tasks.add(asyncio.create_task(run_scheduler()))
             else:
                 # Use another thread to schedule a trio Task
                 trio_token = trio.lowlevel.current_trio_token()
@@ -439,7 +450,7 @@ class Caller:
                 def to_thread() -> None:
                     utils.mark_thread_pydev_do_not_trace()
                     try:
-                        trio.from_thread.run(run_caller_in_context, trio_token=trio_token)
+                        trio.from_thread.run(run_scheduler, trio_token=trio_token)
                     except (BaseExceptionGroup, BaseException) as e:
                         if not "shutdown" not in str(e):
                             raise
@@ -456,7 +467,7 @@ class Caller:
                     host_options=self.host_options,
                 )
                 try:
-                    async_kernel.event_loop.run(run_caller_in_context, (), settings)
+                    async_kernel.event_loop.run(run_scheduler, (), settings)
                 except Exception as e:
                     if not self._stopping.done():
                         self.stop(force=True)
@@ -501,22 +512,6 @@ class Caller:
             case _:
                 pass
         return True
-
-    async def _run_scheduler(self):
-        """Run the scheduler until stopped."""
-        try:
-            with self._inst_lock:
-                if not self._set_state(CallerState.running):
-                    return
-            async with task_factory() as create_task:
-                create_task(contextvars.Context(), self._scheduler, self._queue)
-                await self._stopping
-                await self._guest_done_event
-                await self._children_countdown
-        finally:
-            with self._inst_lock:
-                self._set_state(CallerState.stopping)
-                self._set_state(CallerState.stopped)
 
     async def _scheduler(self, queue: SingleAsyncQueue) -> None:
         """A function that async iterates the queue and executes items as they arrive.

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -131,6 +131,15 @@ class Caller:
 
     Code execution is always done within the context of an asynchronous backend.
 
+    Caller can run in any thread where a backend ('asyncio' or 'trio') is running.  But
+    in-order to start, it must be Created inside that thread. After which, methods can
+    be called from any thread.
+
+    An async context is provided for lifecycle management. The async-context of a caller
+    can be entered multiple times from any thread.  Once entered, a count of contexts
+    is maintained. When the count returns to zero `caller.stop(force=True)` is called.
+    A caller is marked as 'protected' once a context has been entered.
+
     **High level methods**
 
     - [Caller.call_soon][]: Schedule a function call in the caller's thread.
@@ -218,7 +227,7 @@ class Caller:
 
     _pending_var: contextvars.ContextVar[Pending | None] = contextvars.ContextVar("_pending_var", default=None)
 
-    log: logging.Logger | logging.LoggerAdapter
+    log: logging.LoggerAdapter
     ""
 
     @property
@@ -374,8 +383,7 @@ class Caller:
             inst._host = host
             inst._backend_options = kwargs.get("backend_options")
             inst._host_options = kwargs.get("host_options")
-            inst._protected = kwargs.get("protected", False)
-            inst.log = kwargs.get("log") or logging.LoggerAdapter(logging.getLogger())
+            inst.log = logging.LoggerAdapter(logging.getLogger())
 
             # Set the scheduler to start in either the current thread or a new thread.
             # It is not possible to wait for it to start without using microthreads like greenlets.
@@ -386,18 +394,20 @@ class Caller:
         return inst
 
     async def __aenter__(self) -> Self:
-        if self._stopping.done():
-            msg = "The caller is stopping!"
-            raise RuntimeError(msg)
+        self._protected = True
         await self.started
-        self._enter_count = self._enter_count + 1
+        with self._inst_lock:
+            if self._stopping.done():
+                msg = f"This caller is stopping or stopped {self}"
+                raise RuntimeError(msg)
+            self._enter_count = self._enter_count + 1
         return self
 
     async def __aexit__(self, type, value, traceback) -> Literal[False]:
-        self._enter_count = self._enter_count - 1
+        with self._inst_lock:
+            self._enter_count = self._enter_count - 1
         if self._enter_count == 0:
             self.stop(force=True)
-        if self._stopping.done():
             await self.stopped.wait(shield=True)
         return False
 
@@ -470,8 +480,8 @@ class Caller:
                     async_kernel.event_loop.run(run_scheduler, (), settings)
                 except Exception as e:
                     if not self._stopping.done():
-                        self.stop(force=True)
                         self.started.set_exception(e)
+                        self.stop(force=True)
 
             thread = threading.Thread(target=async_kernel_caller, name=self._name or None)
             if no_debug:
@@ -490,6 +500,7 @@ class Caller:
             case CallerState.running:
                 self.started.set_result(None)
             case CallerState.stopping:
+                self.started.cancel("Stopping")
                 self._stopping.set_result(None)
                 # Remove from worker pool
                 if (parent := self.parent) and (workers := parent._worker_pool):

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -313,10 +313,6 @@ class Caller:
         children = "" if not n else (" 1 child" if n == 1 else f" {n} children")
         return f"<Caller {current}{self._state_reprs[self._state]}{protected}{info}{children}>"
 
-    def __del__(self) -> None:
-        if self._state not in [CallerState.stopping, CallerState.stopped]:
-            self.stop(force=True)
-
     def __new__(
         cls,
         modifier: Literal["CurrentThread", "MainThread", "NewThread"] = "CurrentThread",
@@ -420,8 +416,7 @@ class Caller:
             no_debug: If debugpy should be disabled in the thread.
         """
         with self._inst_lock:
-            if not self._set_state(CallerState.start_sync):
-                return
+            self._set_state(CallerState.start_sync)
 
         async def run_scheduler() -> None:
             with self._inst_lock:
@@ -432,11 +427,10 @@ class Caller:
             if no_debug:
                 utils.mark_thread_pydev_do_not_trace()
             try:
-                with self._inst_lock:
-                    if not self._set_state(CallerState.running):
-                        return
                 async with task_factory() as create_task:
                     create_task(contextvars.Context(), self._scheduler, self._queue)
+                    with self._inst_lock:
+                        self._set_state(CallerState.running)
                     await self._stopping
                     await self._guest_done_event
                     await self._children_countdown

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -188,6 +188,7 @@ class Caller:
     _enter_count = 0
     _state_reprs: ClassVar[dict] = {
         CallerState.initial: "❗ not running",
+        CallerState.start_sync: "pre-start",
         CallerState.starting: "starting",
         CallerState.running: "🏃 running",
         CallerState.stopping: "🏁 stopping",
@@ -205,6 +206,7 @@ class Caller:
     )
     _guest_queues: Fixed[Self, dict[Backend, SingleAsyncQueue[Pending | tuple[Callable, tuple, dict]]]] = Fixed(dict)
     _guest_done_event: Fixed[Any, CountdownEvent] = Fixed(CountdownEvent)
+    _children_countdown: Fixed[Any, CountdownEvent] = Fixed(CountdownEvent)
     _stopping = Fixed(Pending[None])
     "A pending that is set done the first time stop is called."
 
@@ -214,7 +216,6 @@ class Caller:
     stopped = Fixed(Pending)
     "A pending that is done when the caller is stopped."
 
-    _children_countdown: CountdownEvent | None = None
     _pending_var: contextvars.ContextVar[Pending | None] = contextvars.ContextVar("_pending_var", default=None)
 
     log: logging.Logger | logging.LoggerAdapter
@@ -261,14 +262,14 @@ class Caller:
         return self._state is CallerState.running
 
     @property
-    def children(self) -> frozenset[Self]:
+    def children(self) -> set[Self]:
         """A frozenset copy of the instances that were created by the caller.
 
         Notes:
             - When the parent is stopped, all children are stopped.
-            - All children are stopped prior to the parent exiting its async context.
+            - All children are stopped prior to the parent changing state to stopped.
         """
-        return frozenset(self._children)
+        return {c for c in self._children.copy() if not c._stopping.done()}
 
     @property
     def thread(self) -> threading.Thread:
@@ -284,6 +285,8 @@ class Caller:
         return None
 
     def _get_info(self) -> dict[str, Any]:
+        if self._state.value < CallerState.running.value:
+            return {"name": self._name, "backend": str(self._backend), "host": self._host}
         return {
             "name": self._name,
             "backend": str(self._backend),
@@ -295,11 +298,15 @@ class Caller:
     @override
     def __repr__(self) -> str:
         info = " ".join(f"{k}={v!r}" for k, v in self._get_info().items())
-        current = "⚪" if self.id_current() == self._caller_id else "⚫"
+        current = "⚪" if self.id_current() == getattr(self, "_caller_id", None) else "⚫"
         protected = "🔐 " if self.protected else " "
         n = len(self._children)
         children = "" if not n else (" 1 child" if n == 1 else f" {n} children")
         return f"<Caller {current}{self._state_reprs[self._state]}{protected}{info}{children}>"
+
+    def __del__(self) -> None:
+        if self._state not in [CallerState.stopping, CallerState.stopped]:
+            self.stop(force=True)
 
     def __new__(
         cls,
@@ -358,7 +365,6 @@ class Caller:
 
             # create a new instance
             inst = super().__new__(cls)
-            inst._state = CallerState.initial
             if (sys.platform == "emscripten") and (caller_id is None):
                 caller_id = id(inst)
 
@@ -399,20 +405,20 @@ class Caller:
         """Start synchronously.
 
         Args:
-            caller_id: The id of the caller.
+            caller_id: The id to use for the caller, which should match the thread in CPython.
             thread: The thread where the caller is running.
             no_debug: If debugpy should be disabled in the thread.
         """
-        assert self._state is CallerState.initial
-        self._state = CallerState.starting
+        with self._inst_lock:
+            if not self._set_state(CallerState.start_sync):
+                return
 
         async def run_caller_in_context() -> None:
-            if self._state in [CallerState.stopping, CallerState.stopped]:
-                return
+            with self._inst_lock:
+                if not self._set_state(CallerState.starting):
+                    return
             if not self._name:
                 self._name = self._thread.name
-            if self._state is CallerState.starting:
-                self._state = CallerState.initial
             if no_debug:
                 utils.mark_thread_pydev_do_not_trace()
             try:
@@ -457,9 +463,41 @@ class Caller:
                         self.started.set_exception(e)
 
             thread = threading.Thread(target=async_kernel_caller, name=self._name or None)
+            if no_debug:
+                utils.mark_thread_pydev_do_not_trace(thread)
             thread.start()
             assert thread.ident
             self._thread, self._caller_id = thread, thread.ident
+
+    def _set_state(self, state: CallerState) -> bool:
+        assert self._inst_lock.value == 0, "Must be locked to set the state!"
+        if state.value <= self._state.value:
+            return False
+        self._state = state
+        self.log.debug("%s %s", state.name.capitalize(), self)
+        match state:
+            case CallerState.running:
+                self.started.set_result(None)
+            case CallerState.stopping:
+                self._stopping.set_result(None)
+                # Remove from worker pool
+                if (parent := self.parent) and (workers := parent._worker_pool):
+                    with contextlib.suppress(ValueError):
+                        workers.remove(self)
+                # Invoke stop callbacks
+                for child in self._children.copy():
+                    child.stop(force=True)
+                # Shutdown queue_call
+                for func in self._queue_map.copy():
+                    self.queue_close(func)
+            case CallerState.stopped:
+                self._children_countdown.wait()
+                self._instances.pop(self._caller_id)
+                self._queue.stop()
+                self.stopped.set_result(None)
+            case _:
+                pass
+        return True
 
     def stop(self, *, force: bool = False) -> None:
         """Stop the caller cancelling all incomplete tasks.
@@ -475,64 +513,30 @@ class Caller:
             self.log.warning("Non-force stop ignored for  %s", self)
             return
         with self._inst_lock:
-            if self._stopping.done():
-                return
             state = self._state
-            self._state = CallerState.stopping
-            self._stopping.set_result(None)
-            self.log.debug("Stopping %s", self)
-            # Remove from worker pool
-            if (parent := self.parent) and (workers := parent._worker_pool):
-                with contextlib.suppress(ValueError):
-                    workers.remove(self)
-            # Invoke stop callbacks
-            for child in self._children.copy():
-                child.stop(force=True)
-            # Shutdown queue_call
-            for func in self._queue_map.copy():
-                self.queue_close(func)
-        # Stop the children
-        if state in [CallerState.initial, CallerState.starting]:
-            self._stop_finalize()
+            if (
+                self._set_state(CallerState.stopping)
+                and state.value < CallerState.running.value
+                and not self.stopped.done()
+            ):
+                self._set_state(CallerState.stopped)
 
-    def _stop_finalize(self) -> None:
-        with self._inst_lock:
-            if not self.stopped.done():
-                if (countdown := self._children_countdown) is not None:
-                    countdown.wait()
-                self._instances.pop(self._caller_id)
-                self._queue.stop()
-                self._state = CallerState.stopped
-                self.stopped.set_result(None)
-                self.log.debug("Stopped %s", self)
 
     async def _run_scheduler(self):
-        """The asynchronous context for caller."""
-        if self._state is CallerState.starting:
-            msg = "Already starting! Did you mean to use Caller()?"
-            raise RuntimeError(msg)
-        if self._state is CallerState.stopped:
-            msg = f"Stopped: {self}"
-            raise RuntimeError(msg)
+        """Run the scheduler until stopped."""
         try:
+            with self._inst_lock:
+                if not self._set_state(CallerState.running):
+                    return
             async with task_factory() as create_task:
                 create_task(contextvars.Context(), self._scheduler, self._queue)
-                try:
-                    self._state = CallerState.running
-                    self.log.debug("Started %s", self)
-                    self.started.set_result(None)
-                    await self._stopping
-                finally:
-                    self.stop(force=True)
-                    if self._guest_done_event.value > 0:
-                        # Warning: `queue` must not be stopped until guests have been stopped.
-                        with anyio.CancelScope(shield=True):
-                            await self._guest_done_event
-                    if (countdown := self._children_countdown) is not None:
-                        with anyio.CancelScope(shield=True):
-                            await countdown
+                await self._stopping
+                await self._guest_done_event
+                await self._children_countdown
         finally:
-            self._stop_finalize()
+            with self._inst_lock:
+                self._set_state(CallerState.stopping)
+                self._set_state(CallerState.stopped)
 
     async def _scheduler(self, queue: SingleAsyncQueue) -> None:
         """A function that async iterates the queue and executes items as they arrive.

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import atexit
 import contextlib
 import contextvars
 import inspect
@@ -189,7 +188,7 @@ class Caller:
     _enter_count = 0
     _state_reprs: ClassVar[dict] = {
         CallerState.initial: "❗ not running",
-        CallerState.start_sync: "starting sync",
+        CallerState.starting: "starting",
         CallerState.running: "🏃 running",
         CallerState.stopping: "🏁 stopping",
         CallerState.stopped: "🏁 stopped",
@@ -304,7 +303,7 @@ class Caller:
 
     def __new__(
         cls,
-        modifier: Literal["CurrentThread", "MainThread", "NewThread", "manual"] = "CurrentThread",
+        modifier: Literal["CurrentThread", "MainThread", "NewThread"] = "CurrentThread",
         /,
         **kwargs: Unpack[CallerCreateOptions],
     ) -> Self:
@@ -318,7 +317,6 @@ class Caller:
                 - Advanced:
                     - "NewThread": Create a caller with a new thread.
                         [Caller.get][] and [Caller.to_thread][] are recommended for normal usage.
-                    - "manual": Create a instance for the current thread.
 
             **kwargs: Additional options for Caller creation, such as:
                 - name: The name to use.
@@ -337,18 +335,15 @@ class Caller:
         with cls._lock:
             name, backend = kwargs.get("name", ""), kwargs.get("backend")
             match modifier:
-                case "CurrentThread" | "manual":
-                    caller_id = cls.id_current()
                 case "MainThread":
-                    caller_id = cls.CALLER_MAIN_THREAD_ID
+                    caller_id, thread = cls.CALLER_MAIN_THREAD_ID, threading.main_thread()
                 case "NewThread":
-                    caller_id = None
+                    caller_id, thread = None, None
+                case _:
+                    caller_id, thread = cls.id_current(), threading.current_thread()
 
             # Locate existing
             if caller_id is not None and (caller := cls._instances.get(caller_id)):
-                if modifier == "manual":
-                    msg = f"An instance already exists for {caller_id=}"
-                    raise RuntimeError(msg)
                 if name and name != caller.name:
                     msg = f"The thread and caller's name do not match! {name=} {caller=}"
                     raise ValueError(msg)
@@ -357,30 +352,30 @@ class Caller:
                     raise ValueError(msg)
                 return caller
 
+            host = Hosts(host) if (host := kwargs.get("host")) else None
+            if (backend := Backend(backend or current_async_library())) is Backend.trio:
+                trio.sleep  # noqa: B018 # Check trio is available.
+
             # create a new instance
             inst = super().__new__(cls)
+            inst._state = CallerState.initial
+            if (sys.platform == "emscripten") and (caller_id is None):
+                caller_id = id(inst)
+
+            # Apply settings
             inst._name = name
-            inst._backend = Backend(backend or current_async_library())
-            if inst._backend is Backend.trio:
-                trio.sleep  # noqa: B018 # Check trio is available.
-            inst._host = Hosts(loop) if (loop := kwargs.get("host")) else None
+            inst._backend = backend
+            inst._host = host
             inst._backend_options = kwargs.get("backend_options")
             inst._host_options = kwargs.get("host_options")
             inst._protected = kwargs.get("protected", False)
             inst.log = kwargs.get("log") or logging.LoggerAdapter(logging.getLogger())
-            if (sys.platform == "emscripten") and (caller_id is None):
-                caller_id = id(inst)
-            if caller_id is not None:
-                inst._caller_id = caller_id
-                inst._thread = threading.current_thread()
 
-            # finalize
-            if modifier != "manual":
-                inst._start_sync(no_debug=kwargs.get("no_debug", False))
-            assert inst._caller_id
+            # Set the scheduler to start in either the current thread or a new thread.
+            # It is not possible to wait for it to start without using microthreads like greenlets.
+            inst._start_sync(caller_id, thread, kwargs.get("no_debug", False))
+            assert inst._caller_id is not None
             assert inst._caller_id not in cls._instances
-            atexit.register(inst.stop, force=True)
-            inst._stopping.add_done_callback(lambda _: atexit.unregister(inst.stop))
             cls._instances[inst._caller_id] = inst
         return inst
 
@@ -388,9 +383,6 @@ class Caller:
         if self._stopping.done():
             msg = "The caller is stopping!"
             raise RuntimeError(msg)
-        assert self.get_existing() is self, "Invalid thread"
-        if self._state is CallerState.initial:
-            self._start_sync()
         await self.started
         self._enter_count = self._enter_count + 1
         return self
@@ -403,21 +395,23 @@ class Caller:
             await self.stopped.wait(shield=True)
         return False
 
-    def _start_sync(self, *, no_debug: bool = False) -> None:
+    def _start_sync(self, caller_id: int | None, thread: threading.Thread | None, no_debug: bool = False) -> None:
         """Start synchronously.
 
         Args:
+            caller_id: The id of the caller.
+            thread: The thread where the caller is running.
             no_debug: If debugpy should be disabled in the thread.
         """
         assert self._state is CallerState.initial
-        self._state = CallerState.start_sync
+        self._state = CallerState.starting
 
         async def run_caller_in_context() -> None:
             if self._state in [CallerState.stopping, CallerState.stopped]:
                 return
             if not self._name:
                 self._name = self._thread.name
-            if self._state is CallerState.start_sync:
+            if self._state is CallerState.starting:
                 self._state = CallerState.initial
             if no_debug:
                 utils.mark_thread_pydev_do_not_trace()
@@ -426,8 +420,9 @@ class Caller:
             except Exception as e:
                 self.log.exception("Caller did not exit context nicely!", exc_info=e)
 
-        if hasattr(self, "_thread"):
-            assert self._thread is threading.current_thread()
+        if caller_id and thread:
+            assert thread is threading.current_thread()
+            self._thread, self._caller_id = thread, caller_id
 
             if self.backend == Backend.asyncio:
                 self._tasks.add(asyncio.create_task(run_caller_in_context()))
@@ -459,8 +454,7 @@ class Caller:
                 except Exception as e:
                     if not self._stopping.done():
                         self.stop(force=True)
-                        self.log.exception("%s exited early", self, exc_info=e)
-                        raise
+                        self.started.set_exception(e)
 
             thread = threading.Thread(target=async_kernel_caller, name=self._name or None)
             thread.start()
@@ -498,7 +492,7 @@ class Caller:
             for func in self._queue_map.copy():
                 self.queue_close(func)
         # Stop the children
-        if state in [CallerState.initial, CallerState.start_sync]:
+        if state in [CallerState.initial, CallerState.starting]:
             self._stop_finalize()
 
     def _stop_finalize(self) -> None:
@@ -514,8 +508,8 @@ class Caller:
 
     async def _run_scheduler(self):
         """The asynchronous context for caller."""
-        if self._state is CallerState.start_sync:
-            msg = 'Already starting! Did you mean to use Caller("manual")?'
+        if self._state is CallerState.starting:
+            msg = "Already starting! Did you mean to use Caller()?"
             raise RuntimeError(msg)
         if self._state is CallerState.stopped:
             msg = f"Stopped: {self}"

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -119,7 +119,7 @@ async def task_factory() -> AsyncGenerator[Callable[[contextvars.Context | None,
 
 
 @final
-class Caller(anyio.AsyncContextManagerMixin):
+class Caller:
     """A thread-local class that facilitates inter-thread function and coroutine scheduling in asynchronous backends (asyncio or trio).
 
     - CPython: there is only one caller instance per thread.
@@ -186,6 +186,7 @@ class Caller(anyio.AsyncContextManagerMixin):
     _protected = False
     _use_safe_checkpoint = False
     _state: CallerState = CallerState.initial
+    _enter_count = 0
     _state_reprs: ClassVar[dict] = {
         CallerState.initial: "❗ not running",
         CallerState.start_sync: "starting sync",
@@ -207,6 +208,9 @@ class Caller(anyio.AsyncContextManagerMixin):
     _guest_done_event: Fixed[Any, CountdownEvent] = Fixed(CountdownEvent)
     _stopping = Fixed(Pending[None])
     "A pending that is set done the first time stop is called."
+
+    started = Fixed(Pending)
+    "A pending that is set once the caller has started."
 
     stopped = Fixed(Pending)
     "A pending that is done when the caller is stopped."
@@ -372,7 +376,7 @@ class Caller(anyio.AsyncContextManagerMixin):
 
             # finalize
             if modifier != "manual":
-                inst.start_sync(no_debug=kwargs.get("no_debug", False))
+                inst._start_sync(no_debug=kwargs.get("no_debug", False))
             assert inst._caller_id
             assert inst._caller_id not in cls._instances
             atexit.register(inst.stop, force=True)
@@ -380,7 +384,26 @@ class Caller(anyio.AsyncContextManagerMixin):
             cls._instances[inst._caller_id] = inst
         return inst
 
-    def start_sync(self, *, no_debug: bool = False) -> None:
+    async def __aenter__(self) -> Self:
+        if self._stopping.done():
+            msg = "The caller is stopping!"
+            raise RuntimeError(msg)
+        assert self.get_existing() is self, "Invalid thread"
+        if self._state is CallerState.initial:
+            self._start_sync()
+        await self.started
+        self._enter_count = self._enter_count + 1
+        return self
+
+    async def __aexit__(self, type, value, traceback) -> Literal[False]:
+        self._enter_count = self._enter_count - 1
+        if self._enter_count == 0:
+            self.stop(force=True)
+        if self._stopping.done():
+            await self.stopped.wait(shield=True)
+        return False
+
+    def _start_sync(self, *, no_debug: bool = False) -> None:
         """Start synchronously.
 
         Args:
@@ -399,8 +422,7 @@ class Caller(anyio.AsyncContextManagerMixin):
             if no_debug:
                 utils.mark_thread_pydev_do_not_trace()
             try:
-                async with self:
-                    await self._stopping.wait(result=False)
+                await self._run_scheduler()
             except Exception as e:
                 self.log.exception("Caller did not exit context nicely!", exc_info=e)
 
@@ -490,8 +512,7 @@ class Caller(anyio.AsyncContextManagerMixin):
                 self.stopped.set_result(None)
                 self.log.debug("Stopped %s", self)
 
-    @asynccontextmanager
-    async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
+    async def _run_scheduler(self):
         """The asynchronous context for caller."""
         if self._state is CallerState.start_sync:
             msg = 'Already starting! Did you mean to use Caller("manual")?'
@@ -503,11 +524,10 @@ class Caller(anyio.AsyncContextManagerMixin):
             async with task_factory() as create_task:
                 create_task(contextvars.Context(), self._scheduler, self._queue)
                 try:
-                    with anyio.CancelScope() as scope:
-                        self._stopping.add_done_callback(lambda _: self.call_direct(scope.cancel, "Stopping"))
-                        self._state = CallerState.running
-                        self.log.debug("Started %s", self)
-                        yield self
+                    self._state = CallerState.running
+                    self.log.debug("Started %s", self)
+                    self.started.set_result(None)
+                    await self._stopping
                 finally:
                     self.stop(force=True)
                     if self._guest_done_event.value > 0:
@@ -940,7 +960,7 @@ class Caller(anyio.AsyncContextManagerMixin):
 
                     async def queue_loop() -> None:
                         pen = self.current_pending()
-                        assert pen
+                        assert pen is not None
                         try:
                             async for item in queue:
                                 try:

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -216,13 +216,14 @@ class Caller:
     _guest_queues: Fixed[Self, dict[Backend, SingleAsyncQueue[Pending | tuple[Callable, tuple, dict]]]] = Fixed(dict)
     _guest_done_event: Fixed[Any, CountdownEvent] = Fixed(CountdownEvent)
     _children_countdown: Fixed[Any, CountdownEvent] = Fixed(CountdownEvent)
-    _stopping = Fixed(Pending[None])
-    "A pending that is set done the first time stop is called."
 
-    started = Fixed(Pending)
+    started = Fixed(Pending[None])
     "A pending that is set once the caller has started."
 
-    stopped = Fixed(Pending)
+    stopping = Fixed(Pending[None])
+    "A pending that is set done the first time stop is called."
+
+    stopped = Fixed(Pending[None])
     "A pending that is done when the caller is stopped."
 
     _pending_var: contextvars.ContextVar[Pending | None] = contextvars.ContextVar("_pending_var", default=None)
@@ -278,7 +279,7 @@ class Caller:
             - When the parent is stopped, all children are stopped.
             - All children are stopped prior to the parent changing state to stopped.
         """
-        return {c for c in self._children.copy() if not c._stopping.done()}
+        return {c for c in self._children.copy() if not c.stopping.done()}
 
     @property
     def thread(self) -> threading.Thread:
@@ -392,7 +393,7 @@ class Caller:
     async def __aenter__(self) -> Self:
         self._protected = True
         await self.started.wait(result=False)
-        if self._stopping.done():
+        if self.stopping.done():
             if self._enter_count == 0:
                 await self.stopped
             msg = f"The caller is stopping or stopped {self}"
@@ -432,7 +433,7 @@ class Caller:
                     create_task(contextvars.Context(), self._scheduler, self._queue)
                     with self._inst_lock:
                         self._set_state(CallerState.running)
-                    await self._stopping
+                    await self.stopping
                     await self._guest_done_event
                     await self._children_countdown
             except Exception as e:
@@ -474,7 +475,7 @@ class Caller:
                 try:
                     async_kernel.event_loop.run(run_scheduler, (), settings)
                 except Exception as e:
-                    if not self._stopping.done():
+                    if not self.stopping.done():
                         self.started.set_exception(e)
                         self.stop(force=True)
 
@@ -496,7 +497,7 @@ class Caller:
                 self.started.set_result(None)
             case CallerState.stopping:
                 self.started.cancel("Stopping")
-                self._stopping.set_result(None)
+                self.stopping.set_result(None)
                 # Remove from worker pool
                 if (parent := self.parent) and (workers := parent._worker_pool):
                     with contextlib.suppress(ValueError):
@@ -690,7 +691,7 @@ class Caller:
             - If 'backend' or 'zmq_context' are not specified they are copied from the caller.
         """
         with self._inst_lock:
-            if self._stopping.done():
+            if self.stopping.done():
                 msg = f"Caller is stopping or stopped {self}"
                 raise RuntimeError(msg)
             if name := kwargs.get("name"):
@@ -750,7 +751,7 @@ class Caller:
                 if not (queue := self._guest_queues.get(backend)):
                     queue = SingleAsyncQueue(reject=self._reject)
                     self._guest_queues[backend] = queue
-                    self._stopping.add_done_callback(lambda _: queue.stop())
+                    self.stopping.add_done_callback(lambda _: queue.stop())
 
                     def guest_done_callback(value: Any):
                         self._guest_done_event.down()

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -495,6 +495,9 @@ class Caller:
                 self._instances.pop(self._caller_id)
                 self._queue.stop()
                 self.stopped.set_result(None)
+                if parent := self.parent:
+                    parent._children.discard(self)
+                    parent._children_countdown.down()
             case _:
                 pass
         return True
@@ -700,22 +703,13 @@ class Caller:
                             msg = f"Host mismatch! {host=} {child.host=}"
                             raise RuntimeError(msg)
                         return child
-
             if "backend" not in kwargs:
                 kwargs["backend"] = self._backend
                 kwargs["backend_options"] = self.backend_options
             child = self.__class__("NewThread", **kwargs)
             child._parent_ref = weakref.ref(self)
-            if self._children_countdown is None:
-                self._children_countdown = CountdownEvent()
             self._children.add(child)
             self._children_countdown.up()
-
-            def on_child_stopped(_, children=self._children, done=self._children_countdown.down) -> None:
-                children.discard(child)
-                done()
-
-            child.stopped.add_done_callback(on_child_stopped)
             return child
 
     def schedule_call(

--- a/src/async_kernel/caller.py
+++ b/src/async_kernel/caller.py
@@ -391,12 +391,13 @@ class Caller:
 
     async def __aenter__(self) -> Self:
         self._protected = True
-        await self.started
-        with self._inst_lock:
-            if self._stopping.done():
-                msg = f"This caller is stopping or stopped {self}"
-                raise RuntimeError(msg)
-            self._enter_count = self._enter_count + 1
+        await self.started.wait(result=False)
+        if self._stopping.done():
+            if self._enter_count == 0:
+                await self.stopped
+            msg = f"The caller is stopping or stopped {self}"
+            raise RuntimeError(msg)
+        self._enter_count = self._enter_count + 1
         return self
 
     async def __aexit__(self, type, value, traceback) -> Literal[False]:

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -139,8 +139,8 @@ class BaseMessageApplication(Application, anyio.AsyncContextManagerMixin):
             raise RuntimeError(msg)
         self.backend = Backend(current_async_library())
         channels_started, stop_channels = create_async_waiter(), create_async_event()
-        async with Caller(name="Shell", protected=True, log=self.log, host=self.host) as caller:
-            caller_ctrl = caller.get(name="Control", log=self.log, protected=True)
+        async with Caller(name="Shell") as caller:
+            caller_ctrl = caller.get(name="Control")
             self.callers[Channel.shell] = caller
             self.callers[Channel.control] = caller_ctrl
             pen_channels = caller_ctrl.call_soon(self._open_channels, channels_started.wake, stop_channels)

--- a/src/async_kernel/interface/base.py
+++ b/src/async_kernel/interface/base.py
@@ -139,7 +139,7 @@ class BaseMessageApplication(Application, anyio.AsyncContextManagerMixin):
             raise RuntimeError(msg)
         self.backend = Backend(current_async_library())
         channels_started, stop_channels = create_async_waiter(), create_async_event()
-        async with Caller("manual", name="Shell", protected=True, log=self.log, host=self.host) as caller:
+        async with Caller(name="Shell", protected=True, log=self.log, host=self.host) as caller:
             caller_ctrl = caller.get(name="Control", log=self.log, protected=True)
             self.callers[Channel.shell] = caller
             self.callers[Channel.control] = caller_ctrl

--- a/src/async_kernel/typing.py
+++ b/src/async_kernel/typing.py
@@ -10,7 +10,6 @@ from typing_extensions import Sentinel, TypeVar, get_annotations, override
 
 if TYPE_CHECKING:
     import datetime
-    import logging
 
     from async_kernel.interface import BaseInterface
     from async_kernel.shell import BaseShell
@@ -443,13 +442,6 @@ class CallerCreateOptions(RunSettings):
 
     name: NotRequired[str]
     "The name for the new caller instance."
-
-    log: NotRequired[logging.Logger | logging.LoggerAdapter]
-    "A logger or logging adapter."
-
-    "Options to pass when calling [anyio.run][]."
-    protected: NotRequired[bool]
-    "The caller should be protected against accidental closure (default=`False`)."
 
     no_debug: NotRequired[bool]
     "Disable debugpy in the thread if a new thread is created."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,5 +188,5 @@ def job() -> Job[ExecuteContent]:
 
 @pytest.fixture
 async def caller(anyio_backend: Backend):
-    async with Caller("manual") as caller:
+    async with Caller() as caller:
         yield caller

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import logging
 import os
 import subprocess
 import sys
@@ -14,6 +15,7 @@ import zmq
 from aiologic.lowlevel import current_async_library
 from jupyter_client.asynchronous.client import AsyncKernelClient
 
+import async_kernel
 from async_kernel import Caller
 from async_kernel.interface.zmq import ZMQInterface
 from async_kernel.kernel import Kernel
@@ -35,6 +37,9 @@ else:
     params = [pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio")]
 
 debug = False
+
+if async_kernel.utils.LAUNCHED_BY_DEBUGPY:
+    logging.basicConfig(level=10)
 
 
 @pytest.hookimpl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ else:
 debug = False
 
 if async_kernel.utils.LAUNCHED_BY_DEBUGPY:
+    debug = True
     logging.basicConfig(level=10)
 
 
@@ -49,6 +50,7 @@ def pytest_configure(config):
         debug = True
     if debug:
         traitlets.config.Application.log_level.default_value = 10  # pyright: ignore[reportAttributeAccessIssue]
+        logging.basicConfig(level=10)
 
 
 def check_anyio_backend(anyio_backend):

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -18,7 +18,9 @@ from aiologic.lowlevel import create_async_event, current_async_library
 
 from async_kernel.caller import Caller
 from async_kernel.pending import Pending, PendingCancelled
-from async_kernel.typing import Backend, Hosts
+from async_kernel.typing import Backend, CallerState, Hosts
+
+# pyright: reportPrivateUsage=false
 
 anyio_backends = [("asyncio", {"use_uvloop": False}), ("trio", {})]
 if importlib.util.find_spec("winloop") or importlib.util.find_spec("uvloop"):
@@ -253,6 +255,8 @@ class TestCaller:
     async def test_get_start_main_thread(self, anyio_backend: Backend):
         # Check a caller can be started in the main thread synchronously.
         caller = Caller()
+        assert caller._state.value < CallerState.running.value, "needed for __repr__ early check"
+        assert str(caller)
         assert await caller.call_soon(lambda: 1 + 1) == 2
 
     async def test_get_current_thread(self, anyio_backend: Backend):
@@ -378,7 +382,7 @@ class TestCaller:
         while not collected:
             gc.collect()
             await anyio.sleep(0)
-        assert not any(caller._queue_map)  # pyright: ignore[reportPrivateUsage]
+        assert not any(caller._queue_map)
 
     async def test_call_early(self, anyio_backend: Backend) -> None:
         caller = Caller()
@@ -570,7 +574,7 @@ class TestCaller:
                 assert len(threads) == 2
             else:
                 assert len(threads) > 2
-            assert len(caller._worker_pool) == 2  # pyright: ignore[reportPrivateUsage]
+            assert len(caller._worker_pool) == 2
 
     async def test_as_completed_error(self, caller: Caller):
         def func():
@@ -613,6 +617,15 @@ class TestCaller:
             results.add(await pen)
         assert results == {0, 1}
 
+    async def test_as_completed_current_pending_deadlock(self, caller: Caller):
+        async def f():
+            if pen := caller.current_pending():
+                async for _ in caller.as_completed((pen,)):
+                    pass
+
+        with pytest.raises(RuntimeError, match="deadlock"):
+            await caller.call_soon(f)
+
     async def test_as_completed_empty_iterator(self, caller: Caller) -> None:
         async for _ in caller.as_completed(iter(())):
             pass
@@ -630,17 +643,17 @@ class TestCaller:
         pen1 = caller.to_thread(threading.get_ident)
         w1 = Caller.get_existing(await pen1)
         assert w1
-        assert w1 in caller._worker_pool  # pyright: ignore[reportPrivateUsage]
+        assert w1 in caller._worker_pool
         w1.stop()
         pen2 = caller.to_thread(threading.get_ident)
         await w1.stopped
-        assert w1 not in caller._worker_pool  # pyright: ignore[reportPrivateUsage]
+        assert w1 not in caller._worker_pool
         w2 = Caller.get_existing(await pen2)
         assert w2
         assert not w2.stopped.done()
         w2.stop()
         await w2.stopped
-        assert not caller._worker_pool  # pyright: ignore[reportPrivateUsage]
+        assert not caller._worker_pool
 
     async def test_idle_worker_shutdown(self, caller: Caller, mocker):
         mocker.patch.object(Caller, "IDLE_WORKER_SHUTDOWN_DURATION", new=0.1)

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -156,7 +156,7 @@ class TestCaller:
     async def test_stopping(self, anyio_backend: Backend):
         caller = Caller("NewThread")
         caller.stop()
-        with pytest.raises(PendingCancelled):
+        with pytest.raises(RuntimeError):
             async with caller:
                 pass
         assert caller.stopped.done()

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -134,7 +134,6 @@ class TestCaller:
     async def test_manual_stop(self):
         async with Caller("manual") as caller:
             caller.stop()
-            await anyio.sleep_forever()
 
     async def test_call_returns_result(self, caller: Caller) -> None:
         pen = Pending()
@@ -206,12 +205,6 @@ class TestCaller:
         assert not caller.children
         with pytest.raises(RuntimeError):
             caller.get()
-
-    async def test_async_enter_missing_modifier(self, anyio_backend: Backend):
-        with pytest.raises(RuntimeError, match="Already starting! Did you mean to use"):
-            async with Caller():
-                pass
-        Caller().stop()
 
     async def test_call_soon_cancelled_early(self, caller: Caller):
         pen = caller.call_soon(anyio.sleep_forever)
@@ -357,7 +350,7 @@ class TestCaller:
 
         caller.queue_call(test_func)
         pen = caller.queue_get(test_func)
-        assert pen
+        assert pen is not None
         await started
         pen.cancel()
         await pen.wait(result=False)
@@ -401,9 +394,8 @@ class TestCaller:
     async def test_prevent_multi_entry(self, anyio_backend: Backend):
         async with Caller("manual") as caller:
             assert caller is Caller()
-            with pytest.raises(RuntimeError):
-                async with caller:
-                    pass
+            async with caller:
+                pass
         assert caller.stopped.done()
         await caller.stopped
         with pytest.raises(RuntimeError):
@@ -616,15 +608,6 @@ class TestCaller:
             results.add(await pen)
         assert results == {0, 1}
 
-    async def test_as_completed_current_pending_deadlock(self, caller: Caller):
-        async def f():
-            if pen := caller.current_pending():
-                async for _ in caller.as_completed((pen,)):
-                    pass
-
-        with pytest.raises(RuntimeError, match="deadlock"):
-            await caller.call_soon(f)
-
     async def test_as_completed_empty_iterator(self, caller: Caller) -> None:
         async for _ in caller.as_completed(iter(())):
             pass
@@ -735,8 +718,9 @@ class TestCaller:
         async with Caller("manual") as caller:
             opposite = next(b for b in Backend if b is not caller.backend)
             assert await caller.call_using_backend(opposite, lambda: 1 + 1) == 2
+            pen = caller.call_using_backend(opposite, lambda: 1 + 1)
             caller.stop()
-            await anyio.sleep_forever()
+        assert pen.cancelled()
 
     async def test_caller_with_host(self, anyio_backend: Backend):
 

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -54,30 +54,30 @@ class TestCaller:
         thread.join()
         assert okay
 
-    async def test_worker_lifecycle(self, anyio_backend: Backend):
-        async with Caller(name="manual") as caller:
-            assert not caller.protected
+    async def test_child_lifecycle(self, anyio_backend: Backend):
+        async with Caller() as caller:
             # worker thread
             assert await caller.to_thread(lambda: 2 + 1) == 3
             assert len(caller.children) == 1
             worker = next(iter(caller.children))
             assert worker.id != caller.id
             # Child thread
-            c1 = caller.get(name="c1", protected=True)
-            assert c1 in caller.children
-            assert len(caller.children) == 2
-            assert caller.get(name="c1") is c1
-            wrong_backend = next(b for b in Backend if b != anyio_backend)
-            with pytest.raises(RuntimeError, match="Backend mismatch!"):
-                caller.get(name="c1", backend=wrong_backend)
-            with pytest.raises(RuntimeError, match="Host mismatch!"):
-                caller.get(name="c1", host=Hosts.tk)
-            # A child's child
-            c2 = c1.get(name="c2")
-            assert c2 in c1.children
-            assert c2 not in caller.children
-            assert c1.get(name="c2") is c2
-            assert Caller("MainThread") is caller
+            async with caller.get(name="c1") as c1:
+                assert c1 in caller.children
+                assert len(caller.children) == 2
+                assert caller.get(name="c1") is c1
+                wrong_backend = next(b for b in Backend if b != anyio_backend)
+                with pytest.raises(RuntimeError, match="Backend mismatch!"):
+                    caller.get(name="c1", backend=wrong_backend)
+                with pytest.raises(RuntimeError, match="Host mismatch!"):
+                    caller.get(name="c1", host=Hosts.tk)
+                # A child's child
+                c2 = c1.get(name="c2")
+                assert c2 in c1.children
+                assert c2 not in caller.children
+                assert c1.get(name="c2") is c2
+                assert Caller("MainThread") is caller
+            assert c1.stopped.done()
 
         assert not caller.children
         assert c1.stopped.done()
@@ -151,8 +151,17 @@ class TestCaller:
         await pen
         assert re.match(matches[1], repr(pen))
 
+    async def test_stopping(self, anyio_backend: Backend):
+        caller = Caller("NewThread")
+        caller.stop()
+        with pytest.raises(PendingCancelled):
+            async with caller:
+                pass
+        assert caller.stopped.done()
+
     async def test_protected(self, anyio_backend: Backend):
-        async with Caller(protected=True) as caller:
+        async with Caller() as caller:
+            assert caller.protected
             caller.stop()
             assert not caller.stopped.done()
         assert caller.stopped.done()
@@ -387,7 +396,7 @@ class TestCaller:
         with pytest.raises(ValueError, match="The backend does not match!"):
             Caller(backend=wrong_backend)
 
-    async def test_prevent_multi_entry(self, anyio_backend: Backend):
+    async def test_multi_entry(self, anyio_backend: Backend):
         async with Caller() as caller:
             assert caller is Caller()
             async with caller:

--- a/tests/test_caller.py
+++ b/tests/test_caller.py
@@ -55,7 +55,7 @@ class TestCaller:
         assert okay
 
     async def test_worker_lifecycle(self, anyio_backend: Backend):
-        async with Caller("manual", name="manual") as caller:
+        async with Caller(name="manual") as caller:
             assert not caller.protected
             # worker thread
             assert await caller.to_thread(lambda: 2 + 1) == 3
@@ -82,7 +82,7 @@ class TestCaller:
         assert not caller.children
         assert c1.stopped.done()
         assert c2.stopped.done()
-        c3 = Caller("manual")
+        c3 = Caller()
         c3.stop()
         assert c3.stopped.done()
 
@@ -90,11 +90,9 @@ class TestCaller:
         assert Caller.get_existing(caller.id)
         assert Caller("MainThread") is caller
         assert caller.thread is threading.main_thread()
-        with pytest.raises(RuntimeError, match="An instance already exists for"):
-            Caller("manual")
 
     async def test_start_after(self, anyio_backend: Backend):
-        caller = Caller("manual")
+        caller = Caller()
         assert not caller.running
         pen = caller.call_soon(lambda: 2 + 3)
         async with caller:
@@ -122,7 +120,7 @@ class TestCaller:
         caller.stop()
 
     async def test_call_later(self, anyio_backend: Backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             # We have retries because sleeping can be a bit flaky on CI
             for _ in range(10):
                 start_time = time.monotonic()
@@ -132,7 +130,7 @@ class TestCaller:
             assert dt >= 0.1  # pyright: ignore[reportPossiblyUnboundVariable]
 
     async def test_manual_stop(self):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             caller.stop()
 
     async def test_call_returns_result(self, caller: Caller) -> None:
@@ -154,7 +152,7 @@ class TestCaller:
         assert re.match(matches[1], repr(pen))
 
     async def test_protected(self, anyio_backend: Backend):
-        async with Caller("manual", protected=True) as caller:
+        async with Caller(protected=True) as caller:
             caller.stop()
             assert not caller.stopped.done()
         assert caller.stopped.done()
@@ -169,7 +167,7 @@ class TestCaller:
             is_called.set()
             return args, kwargs
 
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             is_called = Event()
             pen = caller.call_later(0.1, my_func, is_called, *args_kwargs[0], **args_kwargs[1])
             await is_called
@@ -178,7 +176,7 @@ class TestCaller:
 
     async def test_anyio_to_thread(self, anyio_backend: Backend):
         # Test the call works from an anyio thread
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             assert caller.running
             assert caller in Caller.all_callers()
 
@@ -197,7 +195,7 @@ class TestCaller:
         assert caller not in Caller.all_callers()
 
     async def test_usage_example(self, anyio_backend: Backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             child_1 = caller.get()
             child_2 = caller.get(name="asyncio backend", backend="asyncio")
             child_3 = caller.get(name="trio backend", backend="trio")
@@ -227,7 +225,7 @@ class TestCaller:
 
     async def test_cancels_on_exit(self):
         is_cancelled = False
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
 
             async def f():
                 nonlocal is_cancelled
@@ -332,7 +330,7 @@ class TestCaller:
 
     async def test_gc(self, anyio_backend: Backend):
         collected = Event()
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             assert await caller.call_soon(lambda: 1 + 1) == 2
             weakref.finalize(caller, collected.set)
             del caller
@@ -374,13 +372,11 @@ class TestCaller:
         assert not any(caller._queue_map)  # pyright: ignore[reportPrivateUsage]
 
     async def test_call_early(self, anyio_backend: Backend) -> None:
-        caller = Caller("manual")
-        assert not caller.running
+        caller = Caller()
         pen = caller.call_soon(lambda: 3 + 3)
-        await anyio.sleep(delay=0.1)
+        assert not caller.running
         assert not pen.done()
-        async with caller:
-            assert await pen == 6
+        assert await pen == 6
 
     async def test_name_mismatch(self, caller: Caller):
         with pytest.raises(ValueError, match="The thread and caller's name do not match!"):
@@ -392,7 +388,7 @@ class TestCaller:
             Caller(backend=wrong_backend)
 
     async def test_prevent_multi_entry(self, anyio_backend: Backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             assert caller is Caller()
             async with caller:
                 pass
@@ -403,13 +399,13 @@ class TestCaller:
                 pass
 
     async def test_current_pending(self, anyio_backend: Backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             pen = caller.call_soon(Caller.current_pending)
             res = await pen
             assert res is pen
 
     async def test_closed_in_call_soon(self):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             never_called_result = caller.call_later(10, anyio.sleep_forever)
 
         with pytest.raises(PendingCancelled):
@@ -544,7 +540,7 @@ class TestCaller:
 
         threads = set[threading.Thread]()
         n = 40
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             # check can handle completed result okay first
             pen = caller.call_soon(lambda: 1 + 2)
             assert await pen.wait() == 3
@@ -576,7 +572,7 @@ class TestCaller:
                 await pen
 
     async def test_as_completed_cancelled(self, anyio_backend: Backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             n = 6
             ready = CountdownEvent(n - 2)
 
@@ -685,7 +681,7 @@ class TestCaller:
         assert results == ["call_direct", "queue_call", "call_soon"] * n
 
     async def test_call_soon_with_backend(self):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             opposite = next(b for b in Backend if b is not caller.backend)
 
             async def check_backend(backend: Backend, fail=False):
@@ -715,7 +711,7 @@ class TestCaller:
             assert pen.result() == opposite
 
     async def test_call_soon_with_backend_cancel(self, anyio_backend):
-        async with Caller("manual") as caller:
+        async with Caller() as caller:
             opposite = next(b for b in Backend if b is not caller.backend)
             assert await caller.call_using_backend(opposite, lambda: 1 + 1) == 2
             pen = caller.call_using_backend(opposite, lambda: 1 + 1)

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -73,7 +73,7 @@ class TestPending:
         result = await pen
         assert result == 42
         assert done_called
-        async with Caller("manual"):
+        async with Caller():
             pen.add_done_callback(callback)
             await after_done
 


### PR DESCRIPTION
- removed some options
  - custom: Callers always begin starting as soon as created
  - log: It now always provides its own log
  - protected: Callers are protected if an async context is used